### PR TITLE
Simplify the RFC process

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,5 +1,6 @@
 * Start Date: YYYY-MM-DD
 * RFC Type: feature / decision / informational
+* Status: draft / active
 * RFC PR: <link>
 
 # Summary

--- a/text/0001-workflow.md
+++ b/text/0001-workflow.md
@@ -31,7 +31,7 @@ There are three types of RFCs:
 
 # Workflow
 
-1. Create a new RFC document as a copy of `0000-template.md`. Name it `XXXX-short-description.md` and commit it directly to the `main` branch. Anyone can do this at any time. Publishing a new doc to `main` is the "request" in RFC.
+1. Create a new RFC document as a copy of `0000-template.md`. Name it `XXXX-short-description.md` (number it one greater than the current max) and commit it directly to the `main` branch. Anyone can do this at any time. Publishing a new doc to `main` is the "request" in RFC.
 1. Modify your RFC directly on `main` until other people care about it, then switch to PRs. PRs (or Issues, etc.) are the "comments" in RFC.
 1. For non-informational RFCs, updating the RFC status to `approved` _must_ happen in a PR, with relevant parties signing off.
 

--- a/text/0001-workflow.md
+++ b/text/0001-workflow.md
@@ -31,9 +31,9 @@ There are three types of RFCs:
 
 # Workflow
 
-1. Create a new RFC document as a copy of `0000-template.md`. Name it `XXXX-short-description.md` and commit it directly to the `main` branch. Anyone can do this at any time.
-1. Modify your RFC directly on `main` or through PRs as you see fit, except that ...
-1. For non-informational RFCs, updating the RFC status to `approved` must happen in a PR, with relevant parties signing off.
+1. Create a new RFC document as a copy of `0000-template.md`. Name it `XXXX-short-description.md` and commit it directly to the `main` branch. Anyone can do this at any time. Publishing a new doc to `main` is the "request" in RFC.
+1. Modify your RFC directly on `main` until other people care about it, then switch to PRs. PRs (or Issues, etc.) are the "comments" in RFC.
+1. For non-informational RFCs, updating the RFC status to `approved` _must_ happen in a PR, with relevant parties signing off.
 
 If you are writing a DACI style RFC, read "Instructions for running this Play" (10 mins) from
 [Atlassian's Playbook](https://www.atlassian.com/team-playbook/plays/daci).  Mention informed and contributors in the RFC and have approver sign off on the `approved` PR.

--- a/text/0001-workflow.md
+++ b/text/0001-workflow.md
@@ -12,15 +12,15 @@ This RFC describes the Sentry RFC process.
 This document exists so that future RFC creators and editors have a workflow to go by.  This workflow is inspired by
 common RFC processes from the Open Source community (Rust RFCs, Python PEPs) but also our internal use of DACIs.
 
-# RFC Type
+# Type
 
-The are three kinds of RFCs:
+There are three types of RFCs:
 
 * a **feature** RFC is a RFC describing a new feature to Sentry, an SDK, the protocol or something else that requires a decision to be made.
-* a **decision** RFC is a DACI style RFC that tries to capture a contended decision that requires circulation.
+* a **decision** RFC is a [DACI](https://www.atlassian.com/team-playbook/plays/daci) style RFC that tries to capture a contended decision that requires circulation.
 * an **informational** RFC is an RFC that provides guidelines, describes an issue or states a longer term plan that does not directly turn into implementation.
 
-# RFC Status
+# Status
 
 * `draft`: this RFC is currently in draft state.
 * `active`: this RFC is currently active which means that the content of the document reference the current state of affairs and are supposed to be followed.
@@ -29,32 +29,21 @@ The are three kinds of RFCs:
 * `withdrawn`: the RFC was withdrawn.  Typically such RFCs are not visible in the repository as the corresponding PRs are not merged unless they are withdrawn after accepted.
 * `replaced`: the RFC was later replaced by another RFC.
 
-# RFC Creation Workflow
+# Workflow
 
-1. Create a new RFC document as a copy of `0000-template.md`.
-2. Name it `XXXX-short-description.md` and commit it to a new branch.
-3. Create a pull request against the `rfcs` repository.  The number of the pull request then
-   becomes the assigned RFC number filled into `XXXX`.  Zero pad it out to 4 places for better sorting.
-4. Pick an RFC type and write it down on your RFC text into the header.
+1. Create a new RFC document as a copy of `0000-template.md`. Name it `XXXX-short-description.md` and commit it directly to the `main` branch. Anyone can do this at any time.
+1. Modify your RFC directly on `main` or through PRs as you see fit, except that ...
+1. For non-informational RFCs, updating the RFC status to `approved` must happen in a PR, with relevant parties signing off.
 
 If you are writing a DACI style RFC, read "Instructions for running this Play" (10 mins) from
-[Atlassian's Playbook](https://www.atlassian.com/team-playbook/plays/daci).  Mention informed and contributors in the PR
-description and assign the approver to the PR.
+[Atlassian's Playbook](https://www.atlassian.com/team-playbook/plays/daci).  Mention informed and contributors in the RFC and have approver sign off on the `approved` PR.
 
-Comments are to be left on the text for suggestions and in the general GitHub pull request comment system.
+Comments, discussion and suggestions should happen using GitHub issues and pull requests.
 
-# RFC Approval Process
 
-Once the approver (can be a person or a TSC) approved the RFC it gets merged.  At that point these things have to happen:
+# Withdrawing
 
-1. Ensure that the RFC PR link is filled in.
-2. Ensure that the document is named after the PR number if it hasn't yet.
-3. Ensure the RFC is merged and hows up in `text`.
-4. Ensure that a link to the `README.md` file is added for the RFC.
+RFCs do not need to complete.  The creator can always withdraw (status `withdrawn`) the RFC. It can be reopened later.
 
-# RFC Withdrawing
-
-RFCs do not need to complete.  The creator can always withdraw (status `withdrawn`) the RFC at which point the PR is closed.  It can be reopened later.
-
-RFCs that are `active` can be retried by setting the status to `replaced` or `withdrawn`.  The former is to be used if another RFC has since replaced it.
+RFCs that are `active` can be retired by setting the status to `replaced` or `withdrawn`. The former is to be used if another RFC has since replaced it.
 Rather than doing that, it's typically better to edit and update the RFC instead (eg: informational RFCs are living documents).


### PR DESCRIPTION
The current RFC process is confusing because we have two state machines operating independently: GitHub's PR workflow, and the RFC status-based workflow.

I propose that we simplify the RFC process by editing documents directly on `main`, and only moving to PRs once people start to care about it. Of course we would require a PR to change the status of a non-informational RFC to `approved`.

- "request" = push to `main`
- "comments" = issues or PRs against the doc on `main`

If this is approved and merged then the next step would be for current PR authors to merge or close their PRs.

[Rendered RFC](https://github.com/getsentry/rfcs/blob/cwlw/simplify-process/text/0001-workflow.md)