### PR TITLE
Propose new Portable PDB related protocol fields

### DIFF
--- a/text/0013-portable-pdb.md
+++ b/text/0013-portable-pdb.md
@@ -1,0 +1,86 @@
+- Start Date: 2022-09-22
+- RFC Type: feature
+- RFC PR: https://github.com/getsentry/rfcs/pull/13
+
+# Summary
+
+This RFC proposes new protocol fields to help with symbolicating .NET stack traces that use Portable PDBs internally for
+symbolication.
+
+# Motivation
+
+To symbolicate a stack frame using a Portable PDB, we need the following data:
+
+- IL Offset
+- Method Index
+
+Additionally, fetching a Portable PDB from an external Symbol server following the [SSQP specification](https://github.com/dotnet/symstore/blob/main/docs/specs/SSQP_Key_Conventions.md#portable-pdb-signature) needs to have:
+
+- PDB File name
+- PDB Id
+- PDB Checksum
+
+Currently the `SentryStackFrame` type of the `sentry-dotnet` SDK has an
+[`instruction_offset` field](https://github.com/getsentry/sentry-dotnet/blob/57044ff52320c82cf1ca22cceee7125dfb9d1423/src/Sentry/SentryStackFrame.cs#L128-L135),
+which is itself not yet documented on [`develop.sentry.dev`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes).
+
+# Background
+
+The reason this decision or document is required. This section might not always exist.
+
+# Options Considered
+
+## Stack Trace Interface Extensions
+
+We propose to add the following to the [Stack Trace Interface Frame Attributes](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes):
+
+- `instruction_offset: Number`, as it is currently used by the `sentry-dotnet` SDK.
+- `method_index: Number`.
+
+The `instruction_offset` is defined as a JSON `Number`.
+This instruction offset is fetched using the .NET [`StackFrame.GetILOffset`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.stackframe.getiloffset)
+method which returns a `Int32` type.
+
+The `method_index` is a JSON `Number` for similar reasons.
+The method index is derived from the .NET [`MemberInfo.MetadataToken`](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.memberinfo.metadatatoken)
+field which also has type `Int32`. This `MetadataToken` is also using a format that encodes the actual method index as the lower 3 bytes (24 bits).
+
+### Alternatives
+
+WASM stack frames can also refer to the concept of a function index. An alternative would be to use a property named `function_index` for both.
+
+## Debug Meta Interface Extensions
+
+We propose to add the following to the [Debug Images Interface](https://develop.sentry.dev/sdk/event-payloads/debugmeta#debug-images):
+
+- A new debug image type similar to the existing native image types.
+- It should have a `type: "portable-pe"` attribute.
+- A `debug_id: String` attribute with a `DebugId` that is parsed from the [CodeView Debug Directory Entry](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PE-COFF.md#codeview-debug-directory-entry-type-2).
+- A `debug_file: String` attribute with the corresponding PDB file path parsed from the same CodeView Entry.
+- A `debug_checksum: String` attribute that is parsed from the [PDB Checksum Debug Directory Entry](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PE-COFF.md#pdb-checksum-debug-directory-entry-type-19).
+
+### Alternatives
+
+- The proposed `"portable-pe"` spelling is modeled after the current `type: "pe"` usage.
+- The current `type: "pe"` image is referencing a PDB file via its `debug_file` and `debug_id` attributes.
+- An alternative spelling could be `"portable-pdb"`, `"portablepdb"` or `"ppdb"`.
+- The `debug_checksum` attribute name has a similar reason. It is the checksum of the referenced debug file.
+
+# Drawbacks
+
+This increases the complexity and surface area of the Event Payload Interface. However all the proposed fields are
+eventually necessary to offer symbolication for .NET stack traces based on debug data included in Portable PDB files.
+
+# Implementation guidelines
+
+The proposed fields need to be included and parsed in the following parts:
+
+- The `sentry-dotnet` SDK.
+- Relay
+- Symbolicator
+
+# Unresolved questions
+
+- Bikeshed the `method_index` naming.
+- Bikeshed the `"portable-pe"` naming.
+- Do we have a link to documentation for why we need the checksum to do NuGet lookups?

--- a/text/0013-portable-pdb.md
+++ b/text/0013-portable-pdb.md
@@ -61,7 +61,9 @@ This `MetadataToken` is encodes the metadata table in its most significant byte 
 
 ### Open Questions:
 
-- How does WASM symbolication work? How is the concept of a _function index_ being used in WASM?
+- ~~How does WASM symbolication work? How is the concept of a _function index_ being used in WASM?~~
+  - WASM has the context of `function_index`, though it is not useful for symbolication as the module relative instruction offset is enough to do DWARF lookups.
+  - The WASM `function_index` would be useful to look up the function metadata in WASM format, which we do not use.
 - Should we introduce another `addr_mode` to call out "function-relative" addressing explicitly?
 - Should the `function_id` be a `HexValue`, or completely free-form?
 - Should we decode the `MetadataToken` on the client? (filter for only `MethodDef`, and mask away the table id?)

--- a/text/0013-portable-pdb.md
+++ b/text/0013-portable-pdb.md
@@ -129,6 +129,12 @@ The details of this header do not seem to be publicly documented, but can be tra
 - Key Format: https://github.com/dotnet/symstore/blob/aa44862e5028cb7595bbd474da1d63e8c24bf718/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs#L166-L177
 - `SymbolChecksum` Header: https://github.com/dotnet/symstore/blob/8a7c47ac74302510f839cc2361ca591b6f4df542/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs#L112
 
+Another example that rather fetches files from the Microsoft Symbol Server:
+
+- https://msdl.microsoft.com/download/symbols/system.reflection.metadata.dll/858257FE114000/system.reflection.metadata.dll
+- https://msdl.microsoft.com/download/symbols/system.reflection.metadata.pdb/3183ede4e1eb4d0ca6a02937d1f72463FFFFFFFF/system.reflection.metadata.pdb
+- https://msdl.microsoft.com/download/symbols/system.reflection.metadata.ni.pdb/d9f6618dd9346123c7c2459c9645cf841/system.reflection.metadata.ni.pdb
+
 </details>
 
 # Drawbacks
@@ -140,12 +146,16 @@ eventually necessary to offer symbolication for .NET stack traces based on debug
 
 The proposed fields need to be included and parsed in the following parts:
 
-- The `sentry-dotnet` SDK.
-- Relay
-- Symbolicator
+- The `sentry-dotnet` SDK, something along these lines: https://github.com/getsentry/sentry-dotnet/pull/1785
+- Relay: https://github.com/getsentry/relay/blob/95f154409f236ecc8089a4b19534997625a21735/relay-general/src/protocol/stacktrace.rs#L13
+- Sentry:
+- Symbolicator: https://github.com/getsentry/symbolicator/pull/883
 
 # Unresolved questions
 
-- Bikeshed the `method_index` naming.
-- Bikeshed the `"portable-pe"` naming.
-- What should we do for PE files that have multiple CodeView Records?
+- ~~What should we do for PE files that have multiple CodeView Records?~~
+  - Those come from Native Image (ngen) DLLs.
+  - One of those records refers to a `.ni.pdb` in MSF PDB format.
+  - The other one refers to a Portable PDB.
+  - The MSF PDB does not seem to be usable via our native SymCache conversion.
+  - The commendation is thus to simply filter for the `DebugDirectoryEntry.IsPortableCodeView` property.

--- a/text/0013-portable-pdb.md
+++ b/text/0013-portable-pdb.md
@@ -24,9 +24,28 @@ Currently the `SentryStackFrame` type of the `sentry-dotnet` SDK has an
 [`instruction_offset` field](https://github.com/getsentry/sentry-dotnet/blob/57044ff52320c82cf1ca22cceee7125dfb9d1423/src/Sentry/SentryStackFrame.cs#L128-L135),
 which is itself not yet documented on [`develop.sentry.dev`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes).
 
-# Background
+## NuGet Symbol Server
 
-The reason this decision or document is required. This section might not always exist.
+The NuGet symbol server (`https://symbols.nuget.org/download/symbols/{query}`) requires the PDB checksum to be provided via a `SymbolChecksum` header.
+If that header is not provided, the server will always respond with a `403` error code. Otherwise, it uses a `404` code when the symbol is not found.
+
+Examples:
+
+```
+> curl https://symbols.nuget.org/download/symbols/microsoft.maui.pdb/10f7f174e11949f587c4d0b617742d31FFFFFFFF/microsoft.maui.pdb -i
+HTTP/1.1 403 Forbidden
+
+> curl https://symbols.nuget.org/download/symbols/microsoft.maui.pdb/10f7f174e11949f587c4d0b617742d31FFFFFFFF/microsoft.maui.pdb -H "SymbolChecksum: SHA256:74f1f71019e1f5197c4d0b617742d31b515f041c4f62a41bfc25ebb05a7fbff3" -i
+HTTP/1.1 404 Not Found
+```
+
+The details of this header do not seem to be publicly documented, but can be traced by looking through the `symstore` code:
+
+- PdbChecksum: https://github.com/dotnet/symstore/blob/aa44862e5028cb7595bbd474da1d63e8c24bf718/src/Microsoft.FileFormats/PE/PEStructures.cs#L375
+- PE Key: https://github.com/dotnet/symstore/blob/aa44862e5028cb7595bbd474da1d63e8c24bf718/src/Microsoft.SymbolStore/KeyGenerators/PEFileKeyGenerator.cs#L75
+- Portable PDB Key: https://github.com/dotnet/symstore/blob/aa44862e5028cb7595bbd474da1d63e8c24bf718/src/Microsoft.SymbolStore/KeyGenerators/PortablePDBFileKeyGenerator.cs#L85
+- Key Format: https://github.com/dotnet/symstore/blob/aa44862e5028cb7595bbd474da1d63e8c24bf718/src/Microsoft.SymbolStore/KeyGenerators/KeyGenerator.cs#L166-L177
+- `SymbolChecksum` Header: https://github.com/dotnet/symstore/blob/8a7c47ac74302510f839cc2361ca591b6f4df542/src/Microsoft.SymbolStore/SymbolStores/HttpSymbolStore.cs#L112
 
 # Options Considered
 
@@ -57,7 +76,7 @@ We propose to add the following to the [Debug Images Interface](https://develop.
 - It should have a `type: "portable-pe"` attribute.
 - A `debug_id: String` attribute with a `DebugId` that is parsed from the [CodeView Debug Directory Entry](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PE-COFF.md#codeview-debug-directory-entry-type-2).
 - A `debug_file: String` attribute with the corresponding PDB file path parsed from the same CodeView Entry.
-- A `debug_checksum: String` attribute that is parsed from the [PDB Checksum Debug Directory Entry](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PE-COFF.md#pdb-checksum-debug-directory-entry-type-19).
+- A `debug_checksum: String` attribute that is parsed from the [PDB Checksum Debug Directory Entry](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PE-COFF.md#pdb-checksum-debug-directory-entry-type-19). The format for this attribute should be `${algorithm}:${hex-bytes}`, for example `SHA256:xxxx`.
 
 ### Alternatives
 
@@ -83,4 +102,4 @@ The proposed fields need to be included and parsed in the following parts:
 
 - Bikeshed the `method_index` naming.
 - Bikeshed the `"portable-pe"` naming.
-- Do we have a link to documentation for why we need the checksum to do NuGet lookups?
+- What should we do for PE files that have multiple CodeView Records?


### PR DESCRIPTION
This RFC proposes to add new fields to the event protocol to support symbolication of .NET stack frames that use Portable PDB debug files.

[Rendered RFC](https://github.com/getsentry/rfcs/blob/portable-pdb/text/0013-portable-pdb.md)
