### PR TITLE
Auto-Instrumentation UI thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ This repository contains RFCs and DACIs.  Lost?
 * [0016-auto-code-mappings](text/0016-auto-code-mappings.md): Automatic code mappings
 * [0022-response-context](text/0022-response-context.md): Response context
 * [0027-manual-disabling-of-flaky-tests](text/0027-manual-disabling-of-flaky-tests.md): processes for manually disabling flaky tests in `sentry` and `getsentry`
+* [0036-auto-instrumentation-ui-thread](text/0036-auto-instrumentation-ui-thread.md): auto-instrumentation UI thread
 * [0042-gocd-succeeds-freight-as-our-cd-solution](text/0042-gocd-succeeds-freight-as-our-cd-solution.md): plan to replace freight with GoCD

--- a/text/0000-auto-instrumentation-ui-thread.md
+++ b/text/0000-auto-instrumentation-ui-thread.md
@@ -1,0 +1,77 @@
+* Start Date: 2022-11-08
+* RFC Type: decision
+* RFC PR: <link>
+* RFC Status: -
+* RFC Driver: [Roman Zavarnitsyn](https://github.com/romtsn)
+
+# Summary
+
+Add new `ui_thread` attribute to the `data` key-value map of the `Span` interface, indicating whether
+an auto-instrumented span has run on the UI/Main thread.
+
+# Motivation
+
+In order to expand our Performance Issues offering for mobile, we'd like to introduce a new attribute 
+to the `Span.data` key-value map, indicating whether the span has run on the UI/Main thread, which may 
+result in bad application performance, dropped frames, or even App Hangs/ANRs.
+
+This attribute will be used to detect Performance Issues. As a proof-of-concept, we've decided to start
+detecting File I/O operations on main thread as one of the common pitfalls in mobile development. Since
+File I/O is an atomic operation and can't span across multiple threads, we can certainly say that it's
+a performance issue, when we identify that it's running on the UI/Main thread from our instrumentation.
+
+This attribute is also valid for any Frontend SDK.
+
+# Background
+
+Mobile and Desktop developers must be very aware of the UI Thread(s). It's a core part of developing 
+user interfaces and a common source of bad user experience due to unresponsive UI.
+
+File I/O operations on main thread is one of [the common causes](https://developer.android.com/topic/performance/vitals/anr#io-on-main) 
+for slowing down mobile applications and worsening User Experience. They can result in dropped frames, or even worse, 
+in App Hangs/ANR, which can happen if the UI/Main thread is blocked for more than 5 seconds. It is also easy to miss 
+those operations, as they can be hidden under some third-party libraries/SDKs (e.g. image loading library, which does caching).
+
+Since we already offer auto-instrumentation for File I/O operations on mobile platforms (Android, iOS, Dart),
+it will be an easy win for us to start detecting Performance Issues by introducing a relatively small change
+to the `Span.data` map.
+
+[ANR documentation as part of Android Vitals](https://developer.android.com/topic/performance/vitals/anr).
+
+# Options Considered
+
+## Detecting UI/Main thread for all Spans (Option 1)
+
+The approach was to detect whether *any* span (including custom ones) has run on the UI/Main thread or not.
+However, this turned out to be problematic, because we can't certainly say how much time a span spent on the
+UI/Main thread vs other threads. The span might be started on the UI/Main thread, then perform a network
+request on a background thread (a new child span), and then finished back on the UI/Main thread. It's unclear
+whether this span should be marked as run on UI/Main thread or not.
+
+This option would also require quite some changes in the protocol (e.g. having a map of threads with the start/end timestamp pairs)
+as well as frontend changes.
+
+This option has been decided against, due to potential high-complexity of the proper solution or just simply
+infeasiable on some certain platforms.
+
+## Making `ui_thread` attribute part of the protocol (Option 2)
+
+Since this flag is only relevant to Frontent SDKs, and is only used to mark auto-instrumented spans, it was
+decided against adding it to the common `Span` interface of the protocol.
+
+# Drawbacks
+
+The only drawback we found with this approach is that it works only for automatically created spans and
+cannot be expanded to custom spans. However, given, that our auto-instrumentation offering is growing, this 
+should not be a problem. Other potential detectors we could create for detecting performance issues:
+
+* Network I/O on main thread
+* Database operations on main thread
+* Resources (images/audio/video) manipulation on main thread (e.g. decoding, resizing, etc.)
+
+# Unresolved questions
+
+* Should the `ui_thread` attribute be part of the protocol or just a new key in the data bag?
+* How to properly fingerprint the File I/O performance issue? Do we need to provide a `caller_function`, which has 
+performed the File I/O operation?
+* (Out of scope) De-obfuscation/symbolication of the `caller_function`.

--- a/text/0036-auto-instrumentation-ui-thread.md
+++ b/text/0036-auto-instrumentation-ui-thread.md
@@ -84,11 +84,13 @@ An example of a File I/O span payload with the newly added attributes:
 }
 ```
 
-## (De)obfuscation
+## Symbolication
 
-As the `call_stack` may contain obfuscated frames we need to process them server-side, similar to what we already do for 
+As the `call_stack` may contain obfuscated frames we need to symbolicate them server-side, similar to what we already do for 
 [profiles](https://github.com/getsentry/sentry/blob/cf71af372677487d7d0a7fd8ac9dd092f9596cf4/src/sentry/profiles/task.py#L350-L360). 
-In addition, after de-obfuscation, the frames should be filtered to only `in-app` frames, using the `app.app_identifier` context.
+
+To be able to symbolicate the `call_stack` which is part of the `Span` interface server-side, we have to start sending the `debug_meta`
+information for transactions as well.
 
 # Options Considered
 
@@ -120,7 +122,3 @@ should not be a problem. Other potential detectors we could create for detecting
 * Network I/O on main thread
 * Database operations on main thread
 * Resources (images/audio/video) manipulation on main thread (e.g. decoding, resizing, etc.)
-
-# Unresolved questions
-
-* Should we ignore native framework I/O operations, or should we add a new flag in the data bag? iOS screen parser always runs in the UI Thread and the developer has no control over this. Raising issues for this scenario doesn't seems right.

--- a/text/0036-auto-instrumentation-ui-thread.md
+++ b/text/0036-auto-instrumentation-ui-thread.md
@@ -1,6 +1,6 @@
 * Start Date: 2022-11-08
 * RFC Type: decision
-* RFC PR: <link>
+* RFC PR: [#36](https://github.com/getsentry/rfcs/pull/36)
 * RFC Status: -
 * RFC Driver: [Roman Zavarnitsyn](https://github.com/romtsn)
 

--- a/text/0036-auto-instrumentation-ui-thread.md
+++ b/text/0036-auto-instrumentation-ui-thread.md
@@ -74,4 +74,5 @@ should not be a problem. Other potential detectors we could create for detecting
 * Should the `ui_thread` attribute be part of the protocol or just a new key in the data bag?
 * How to properly fingerprint the File I/O performance issue? Do we need to provide a `caller_function`, which has 
 performed the File I/O operation?
+* Should we ignore native framework I/O operations, or should we add a new flag in the data bag? iOS screen parser always runs in the UI Thread and the developer has no control over this. Raising issues for this scenario doesn't seems right.
 * (Out of scope) De-obfuscation/symbolication of the `caller_function`.

--- a/text/0036-auto-instrumentation-ui-thread.md
+++ b/text/0036-auto-instrumentation-ui-thread.md
@@ -6,8 +6,7 @@
 
 # Summary
 
-Add new `blocked_ui_thread` attribute to the `data` key-value map of the [`Span`](https://develop.sentry.dev/sdk/event-payloads/span/) interface, indicating whether
-an auto-instrumented span has run its entire duration on the UI/Main thread.
+Add new `blocked_main_thread` attribute to the `data` key-value map of the [`Span`](https://develop.sentry.dev/sdk/event-payloads/span/) interface, indicating whether an auto-instrumented span has run its entire duration on the UI/Main thread.
 
 # Motivation
 
@@ -42,7 +41,7 @@ to the `Span.data` map.
 
 Add two new attributes to the `data` key-value map of the [`Span`](https://develop.sentry.dev/sdk/event-payloads/span/) interface:
 
-  1. `blocked_ui_thread` - indicates whether the Span has spent its entire duration on the Main/UI thread.
+  1. `blocked_main_thread` - indicates whether the Span has spent its entire duration on the Main/UI thread.
   2. `call_stack` - contains the most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the [`StackFrame`]
   (https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. When possible, should only include `in-app` frames. 
   Used for proper fingerprinting and grouping of the File I/O performance issues.
@@ -60,7 +59,7 @@ An example of a File I/O span payload with the newly added attributes:
   "trace_id": "b2a33f3f79fe4a7c8de3426725a045cb",
   "status": "ok",
   "data": {
-    "blocked_ui_thread": true,
+    "blocked_main_thread": true,
     "call_stack": [
       {
         "function": "onClick",
@@ -107,7 +106,7 @@ as well as frontend changes.
 This option has been decided against, due to potential high-complexity of the proper solution or just simply
 infeasiable on some certain platforms.
 
-## Making `blocked_ui_thread` attribute part of the protocol (Option 2)
+## Making `blocked_main_thread` attribute part of the protocol (Option 2)
 
 Since this flag is only relevant to Frontent SDKs, and is only used to mark auto-instrumented spans, it was
 decided against adding it to the common `Span` interface of the protocol.

--- a/text/0036-auto-instrumentation-ui-thread.md
+++ b/text/0036-auto-instrumentation-ui-thread.md
@@ -6,7 +6,7 @@
 
 # Summary
 
-Add new `ui_thread` attribute to the `data` key-value map of the `Span` interface, indicating whether
+Add new `ui_thread` attribute to the `data` key-value map of the [`Span`](https://develop.sentry.dev/sdk/event-payloads/span/) interface, indicating whether
 an auto-instrumented span has run on the UI/Main thread.
 
 # Motivation

--- a/text/0036-auto-instrumentation-ui-thread.md
+++ b/text/0036-auto-instrumentation-ui-thread.md
@@ -42,8 +42,8 @@ to the `Span.data` map.
 Add two new attributes to the `data` key-value map of the [`Span`](https://develop.sentry.dev/sdk/event-payloads/span/) interface:
 
   1. `blocked_main_thread` - indicates whether the Span has spent its entire duration on the Main/UI thread.
-  2. `call_stack` - contains the most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the [`StackFrame`]
-  (https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. When possible, should only include `in-app` frames. 
+  2. `call_stack` - contains the most relevant stack frames, that lead to the File I/O span. The stack frame should adhere to the 
+  [`StackFrame`](https://develop.sentry.dev/sdk/event-payloads/stacktrace/#frame-attributes) interface. When possible, should only include `in-app` frames. 
   Used for proper fingerprinting and grouping of the File I/O performance issues.
 
 An example of a File I/O span payload with the newly added attributes:
@@ -86,9 +86,9 @@ An example of a File I/O span payload with the newly added attributes:
 
 ## (De)obfuscation
 
-As the `call_stack` may contain obfuscated frames we need to process them server-side, similar to what we already do for [profiles]
-(https://github.com/getsentry/sentry/blob/cf71af372677487d7d0a7fd8ac9dd092f9596cf4/src/sentry/profiles/task.py#L350-L360). In addition, after de-obfuscation, the frames
-should be filtered to only `in-app` frames, using the `app.app_identifier` context.
+As the `call_stack` may contain obfuscated frames we need to process them server-side, similar to what we already do for 
+[profiles](https://github.com/getsentry/sentry/blob/cf71af372677487d7d0a7fd8ac9dd092f9596cf4/src/sentry/profiles/task.py#L350-L360). 
+In addition, after de-obfuscation, the frames should be filtered to only `in-app` frames, using the `app.app_identifier` context.
 
 # Options Considered
 


### PR DESCRIPTION
Add new `blocked_main_thread` attribute to the `data` key-value map of the [`Span`](https://develop.sentry.dev/sdk/event-payloads/span/) interface, indicating whether an auto-instrumented span has run its entire duration on the UI/Main thread.

[Rendered RFC](https://github.com/getsentry/rfcs/blob/feat/file-io-main-thread/text/0036-auto-instrumentation-ui-thread.md)
