### PR TITLE
proposal for time-to-full-display span in ui transactions

### DIFF
--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -2,53 +2,58 @@
 - RFC Type: feature
 - RFC PR: https://github.com/getsentry/rfcs/pull/46
 - RFC Status: draft
-
-# Summary
-
-We want to provide a new span to the automatic ui transactions.
-The ttfd (time-to-full-display) span is a way for the user to notify the sdk that a ui has been fully loaded.
-That is, after all data is retrieved, either by database calls or rest apis, and set into the ui.
-We would create a new span to the ui automatic transactions to measure it, for all screens of the application.
-This rfc is mostly about how we should design the new api.
-
+  
+# Summary. 
+  
+We want to provide a new span to the automatic ui transactions.  
+The ttfd (time-to-full-display) span is a way for the user to notify the sdk that a ui has been fully loaded.  
+That is, after all data is retrieved, either by database calls or rest apis, and set into the ui.  
+We would create a new span to the ui automatic transactions to measure it, for all screens of the application.  
+This rfc is mostly about how we should design the new api.  
+  
 # Motivation
 
-This is useful especially for mobile developers, but could also be useful for web.
-There is no reliable way to automatically detect when a ui is fully drawn, as the "fully drawn" concept itself is dependant upon the developer.
-
-# Background
-
-We have to add a new api to the sdk to allow the user to notify that a ui was fully drawn.
-
+This is useful especially for mobile developers, but could also be useful for web.  
+There is no reliable way to automatically detect when a ui is fully drawn, as the "fully drawn" concept itself is dependant upon the developer.  
+  
+# Background. 
+  
+We have to add a new api to the sdk to allow the user to notify that a ui was fully drawn.  
+  
 # Options Considered
-
-These options were considered for Android, but the same apply to other sdks, too.
-1) Add a `SentryAndroid.reportFullyDrawn(Activity)` static method. We would start the span automatically when an Activity is being created and we would finish it when the api is called.
-Pros: This resembles the system api `Activity.reportFullyDrawn()`, making it immediate to use.
+  
+These options were considered for Android, but the same apply to other sdks, too.  
+1) Add a `SentryAndroid.reportFullyDrawn(Activity)` static method. We would start the span automatically when an Activity is being created and we would finish it when the api is called.  
+  
+Pros:  
+This resembles the system api `Activity.reportFullyDrawn()`, making it immediate to use.  
 Cons:
- - We need the activity this api is called for, and passing an Activity instance to an api is not ideal.
-E.g. Activity A starts -> Activity B starts -> Activity A finishes loading data and the api is called.
-At this point without the activity it was called on, we wouldn't know which span to finish, because the activity B would be at the top of the stack.
- - We need to add an api to `SentryAndroid`, instead of the `Sentry` class used everywhere else, due to Activity dependency.
- - This is not ideal for single activity apps, as it wouldn't work for fragments
- - If the user doesn't call the api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.
-2) Add a `Sentry.monitorFullyDrawn()` api. We would start the span automatically when an Activity is being created. 
-This api would return the span or a custom object to allow the user to finish it autonomously.
-Pros: We can flag the span when the api is called, so that if the user doesn't call the api, we know we can cancel it
-Cons: 
-- Returning the span would allow the user to perform "dangerous" operations. We could solve this by returning a stripped interface to allow only the `finish()` method, or an entirely custom object.
-- If the user doesn't call the api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span. 
-3) Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(ISpan)` api. We would start the span automatically when an Activity is being created. 
-This api would return a uid used by the other api to stop the span.
-Pros: 
-- We can flag the span when the api is called, so that if the user doesn't call the api, we know we can cancel it
-- We don't return any "dangerous" object to the user
-Cons: 
-- We would add and force the user to use 2 apis
-- If the user doesn't call the second api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.
-
+ - We need the activity this api is called for, and passing an Activity instance to an api is not ideal.  
+E.g. Activity A starts -> Activity B starts -> Activity A finishes loading data and the api is called.  
+At this point without the activity it was called on, we wouldn't know which span to finish, because the activity B would be at the top of the stack.  
+ - We need to add an api to `SentryAndroid`, instead of the `Sentry` class used everywhere else, due to Activity dependency.  
+ - This is not ideal for single activity apps, as it wouldn't work for fragments.  
+ - If the user doesn't call the api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
+2) Add a `Sentry.monitorFullyDrawn()` api. We would start the span automatically when an Activity is being created.  
+This api would return the span or a custom object to allow the user to finish it autonomously.  
+  
+Pros:  
+We can flag the span when the api is called, so that if the user doesn't call the api, we know we can cancel it.  
+Cons:
+- Returning the span would allow the user to perform "dangerous" operations. We could solve this by returning a stripped interface to allow only the `finish()` method, or an entirely custom object.  
+- If the user doesn't call the api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
+3) Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(ISpan)` api. We would start the span automatically when an Activity is being created.  
+This api would return a uid used by the other api to stop the span.  
+  
+Pros:
+- We can flag the span when the api is called, so that if the user doesn't call the api, we know we can cancel it.  
+- We don't return any "dangerous" object to the user.  
+Cons:
+- We would add and force the user to use 2 apis.  
+- If the user doesn't call the second api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
+  
 # Unresolved questions
-
-- How long should the timeout be? The Facebook app developers consider a "bad start" a ttfd of 2.5 seconds or more, or an unsuccessful start. 
-This is only for the first screen, as the other screens are usually faster.
+  
+- How long should the timeout be? The Facebook app developers consider a "bad start" a ttfd of 2.5 seconds or more, or an unsuccessful start.  
+This is only for the first screen, as the other screens are usually faster.  
 https://android-developers.googleblog.com/2021/11/improving-app-startup-facebook-app.html

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -36,6 +36,7 @@ These options were considered for Android, but the same apply to other SDKs, too
 
 
 ## 1. SentryAndroid.reportFullyDrawn(Activity) <a name="option-1"></a>
+
 Add a `SentryAndroid.reportFullyDrawn(Activity)` static method. We would start the span automatically when an Activity is being created and we would finish it when the API is called.  
   
 ### Pros
@@ -68,7 +69,7 @@ This API would return the span or a custom object to allow the user to finish it
 
 ## 3. Sentry.monitorFullyDrawn() with UUID <a name="option-3"></a>
 
-Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(UUID)` API. We would start the span automatically when an Activity is being created.  
+Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(UUID)` API. We would start the span automatically when the SDK creates an auto-generated transaction.  
 This API would return a UUID used by the other API to stop the span.  
   
 ### Pros
@@ -98,7 +99,7 @@ Add `monitorFullyDrawn()` and `reportFullyDrawn()` to ISpan. The user gets acces
 ### Cons
 
 - Extra APIs to call.  
-- Keeping a reference of transaction.  
+- Keeping a reference of transaction.
 
 
 ## 5. reportFullyDrawn() on ISpan <a name="option-5"></a>
@@ -112,8 +113,9 @@ Add `reportFullyDrawn()` toISpan. The user gets access to the APM UI transaction
 - User can add more spans via the same API Sentry.span.  
 
 ### Cons
+
 - Extra APIs to call.  
-- Keeping a reference of transaction.
+- Keeping a reference of a transaction.
 - Not knowing when to wait for fully drawn.
 
 
@@ -131,6 +133,7 @@ We would use use a callback from that.
 - Only available from `androidx.activity` library version 1.7, currently in alpha.  
 - This is not ideal for single activity apps, as it wouldn't work for fragments.  
 - Not knowing when to wait for fully drawn.  
+- Only works on Android.
   
 # Unresolved questions
   

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -134,12 +134,6 @@ If the user calls `reportFullyDrawn` and the option wether to wait for calling `
 
 1. [Cons 1-2 of option 5](#option-5-cons)
 
-### Cons
-
-- Extra APIs to call.  
-- Keeping a reference of a transaction.
-- Not knowing when to wait for fully drawn.
-
 
 ## 7. Hook into Android's `FullyDrawnReporter` <a name="option-7"></a>
 

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -22,8 +22,22 @@ We have to add a new API to the SDK to allow the user to notify that the UI was 
 Also, we need the user to specify the span to finish through a parameter, as it cannot be done automatically.  
 E.g. Activity A starts -> Activity B starts -> Activity A finishes loading data and the API is called.  
 At this point without the activity it was called on, we wouldn't know which span to finish, because the activity B would be at the top of the stack.  
+# Final Decision
   
-# Options Considered
+We decided to go with the simplest API possible, from the end user perspective.  
+We are going to add a single new API `Sentry.reportFullDisplayed()`, which will find the last active screen load transaction and finish the `time-to-full-display` span.  
+The active screen load transaction needs to wait for a to-be-defined timeout if the user calls this API.  
+We still have to evaluate all the edge cases.  
+  
+Since we are going to wait for the user to call the manual API, we are going to make it opt-in, otherwise unaware users would have their transactions take much longer without immediate causes.
+  
+Furthermore, we will evaluate if the SDKs should automatically finish the `time-to-full-display` span, as it would greatly push adoption, but with a lot of possible false positives.  
+This consideration will be evaluated after getting feedbacks (or complains) from the users and after checking the feature adoption.  
+  
+We are keeping the considered options as a reference.  
+  
+  
+## Options Considered
 
 * [2. Sentry.monitorFullDisplay() with Span](#option-2)
 * [4. monitorFullDisplay on ISpan](#option-3)

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -5,52 +5,76 @@
   
 # Summary. 
   
-We want to provide a new span to the automatic ui transactions.  
-The ttfd (time-to-full-display) span is a way for the user to notify the sdk that a ui has been fully loaded.  
-That is, after all data is retrieved, either by database calls or rest apis, and set into the ui.  
-We would create a new span to the ui automatic transactions to measure it, for all screens of the application.  
-This rfc is mostly about how we should design the new api.  
+We want to provide a new span to the automatic UI transactions.  
+The TTFD (time-to-full-display) span is a way for the user to notify the SDK that the UI has been fully loaded.  
+That is, after all data is retrieved, either by database calls or rest APIs, and set into the UI.  
+We would create a new span to the UI automatic transactions to measure it, for all screens of the application.  
+This rfc is mostly about how we should design the new API.  
   
 # Motivation
 
 This is useful especially for mobile developers, but could also be useful for web.  
-There is no reliable way to automatically detect when a ui is fully drawn, as the "fully drawn" concept itself is dependant upon the developer.  
+There is no reliable way to automatically detect when UI is fully drawn, as the "fully drawn" concept depends on the developer.  
   
 # Background. 
   
-We have to add a new api to the sdk to allow the user to notify that a ui was fully drawn.  
+We have to add a new API to the SDK to allow the user to notify that the UI was fully drawn.  
+Also, we need the user to specify the span to finish through a parameter, as it cannot be done automatically.  
+E.g. Activity A starts -> Activity B starts -> Activity A finishes loading data and the API is called.  
+At this point without the activity it was called on, we wouldn't know which span to finish, because the activity B would be at the top of the stack.  
   
 # Options Considered
   
-These options were considered for Android, but the same apply to other sdks, too.  
-1) Add a `SentryAndroid.reportFullyDrawn(Activity)` static method. We would start the span automatically when an Activity is being created and we would finish it when the api is called.  
-  
-Pros:  
-This resembles the system api `Activity.reportFullyDrawn()`, making it immediate to use.  
-Cons:
- - We need the activity this api is called for, and passing an Activity instance to an api is not ideal.  
-E.g. Activity A starts -> Activity B starts -> Activity A finishes loading data and the api is called.  
-At this point without the activity it was called on, we wouldn't know which span to finish, because the activity B would be at the top of the stack.  
- - We need to add an api to `SentryAndroid`, instead of the `Sentry` class used everywhere else, due to Activity dependency.  
- - This is not ideal for single activity apps, as it wouldn't work for fragments.  
- - If the user doesn't call the api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
-2) Add a `Sentry.monitorFullyDrawn()` api. We would start the span automatically when an Activity is being created.  
-This api would return the span or a custom object to allow the user to finish it autonomously.  
-  
-Pros:  
-We can flag the span when the api is called, so that if the user doesn't call the api, we know we can cancel it.  
-Cons:
-- Returning the span would allow the user to perform "dangerous" operations. We could solve this by returning a stripped interface to allow only the `finish()` method, or an entirely custom object.  
-- If the user doesn't call the api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
-3) Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(ISpan)` api. We would start the span automatically when an Activity is being created.  
-This api would return a uid used by the other api to stop the span.  
+These options were considered for Android, but the same apply to other SDKs, too.  
+1) Add a `SentryAndroid.reportFullyDrawn(Activity)` static method. We would start the span automatically when an Activity is being created and we would finish it when the API is called.  
   
 Pros:
-- We can flag the span when the api is called, so that if the user doesn't call the api, we know we can cancel it.  
+- This resembles the system API `Activity.reportFullyDrawn()`, making it immediate to use.  
+Cons:
+- We need the activity this API is called for, and passing an Activity instance to an API is not ideal.  
+- We need to add an API to `SentryAndroid`, instead of the `Sentry` class used everywhere else, due to Activity dependency.  
+- This is not ideal for single activity apps, as it wouldn't work for fragments.  
+- If the user doesn't call the API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
+2) Add a `Sentry.monitorFullyDrawn()` API. We would start the span automatically when an Activity is being created.  
+This API would return the span or a custom object to allow the user to finish it autonomously.  
+  
+Pros:
+- We can flag the span when the API is called, so that if the user doesn't call the API, we know we can cancel it.  
+Cons:
+- We don't depend on Activity, making it usable on other platforms, too.  
+- Returning the span would allow the user to perform "dangerous" operations. We could solve this by returning a stripped interface to allow only the `finish()` method, or an entirely custom object.  
+- If the user doesn't call the API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
+- We can't reliably map `Sentry.monitorFullyDrawn()` to the correct APM transaction, unless we force the user to call it in a specific callback, like `Activity.onActivityCreated()`.  
+3) Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(UUID)` API. We would start the span automatically when an Activity is being created.  
+This API would return a UUID used by the other API to stop the span.  
+  
+Pros:
+- We don't depend on Activity, making it usable on other platforms, too.  
+- We can flag the span when the API is called, so that if the user doesn't call the API, we know we can cancel it.  
 - We don't return any "dangerous" object to the user.  
 Cons:
-- We would add and force the user to use 2 apis.  
-- If the user doesn't call the second api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
+- We would add and force the user to use 2 APIs.  
+- If the user doesn't call the second API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.
+- We can't reliably map `Sentry.monitorFullyDrawn()` to the correct APM transaction, unless we force the user to call it in a specific callback, like `Activity.onActivityCreated()`.  
+4) Add `monitorFullyDrawn()` and `reportFullyDrawn()` to ISpan.  
+The user gets access to the APM UI transaction by calling `Sentry.getSpan`, calls `span.monitorFullyDrawn()` and `span.reportFullyDrawn()`.  
+Pros:
+- We don't depend on Activity, making it usable on other platforms, too.  
+- Correlate fully drawn to correct APM transaction.  
+- User can add more spans via the same API Sentry.span.  
+- Knowing when to wait for fully drawn.  
+Cons:
+- Extra APIs to call.  
+- Keeping a reference of transaction.  
+5) Add `reportFullyDrawn()` toISpan. The user gets access to the APM UI transaction by calling `Sentry.getSpan`, and calls `span.monitorFullyDrawn()`.  
+Pros:
+- We don't depend on Activity, making it usable on other platforms, too.  
+- Correlate fully drawn to correct APM transaction.  
+- User can add more spans via the same API Sentry.span.  
+Cons:
+- Extra APIs to call.  
+- Keeping a reference of transaction.
+- Not knowing when to wait for fully drawn.  
   
 # Unresolved questions
   

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -29,7 +29,7 @@ These options were considered for Android, but the same apply to other SDKs, too
 1) Add a `SentryAndroid.reportFullyDrawn(Activity)` static method. We would start the span automatically when an Activity is being created and we would finish it when the API is called.  
   
 Pros:
-- This resembles the system API `Activity.reportFullyDrawn()`, making it immediate to use.  
+- This resembles the system API `Activity.reportFullyDrawn()`, making it obvious how to use.  
 
 Cons:
 - We need the activity this API is called for, and passing an Activity instance to an API is not ideal.  

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -81,6 +81,17 @@ Pros:
 Cons:
 - Extra APIs to call.  
 - Keeping a reference of transaction.
+- Not knowing when to wait for fully drawn.
+6) Hook into Android's new `FullyDrawnReporter` and use a callback from that.  
+
+Pros:
+- Completely automatic and transparent to the user.  
+- We would know the activity that was drawn, so we'd know the span to finish.  
+
+Cons:
+- Would work for first launch of the first Activity only, as the documentation of `Activity.reportFullyDrawn` says `You can safely call this method any time after first launch as well, in which case it will simply be ignored.`  
+- Only available from `androidx.activity` library version 1.7, currently in alpha.  
+- This is not ideal for single activity apps, as it wouldn't work for fragments.  
 - Not knowing when to wait for fully drawn.  
   
 # Unresolved questions

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -26,7 +26,9 @@ At this point without the activity it was called on, we wouldn't know which span
 # Options Considered
   
 These options were considered for Android, but the same apply to other SDKs, too.  
-1) Add a `SentryAndroid.reportFullyDrawn(Activity)` static method. We would start the span automatically when an Activity is being created and we would finish it when the API is called.  
+
+## 1. Add a `SentryAndroid.reportFullyDrawn(Activity)` static method.
+We would start the span automatically when an Activity is being created and we would finish it when the API is called.  
   
 Pros:
 - This resembles the system API `Activity.reportFullyDrawn()`, making it obvious how to use.  
@@ -36,7 +38,11 @@ Cons:
 - We need to add an API to `SentryAndroid`, instead of the `Sentry` class used everywhere else, due to Activity dependency.  
 - This is not ideal for single activity apps, as it wouldn't work for fragments.  
 - If the user doesn't call the API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
-2) Add a `Sentry.monitorFullyDrawn()` API. We would start the span automatically when an Activity is being created.  
+
+
+## 2. Add a `Sentry.monitorFullyDrawn()` API.
+
+We would start the span automatically when an Activity is being created.  
 This API would return the span or a custom object to allow the user to finish it autonomously.  
   
 Pros:
@@ -47,7 +53,10 @@ Cons:
 - Returning the span would allow the user to perform "dangerous" operations. We could solve this by returning a stripped interface to allow only the `finish()` method, or an entirely custom object.  
 - If the user doesn't call the API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
 - We can't reliably map `Sentry.monitorFullyDrawn()` to the correct APM transaction, unless we force the user to call it in a specific callback, like `Activity.onActivityCreated()`.  
-3) Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(UUID)` API. We would start the span automatically when an Activity is being created.  
+
+## 3. Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(UUID)` API.
+
+We would start the span automatically when an Activity is being created.  
 This API would return a UUID used by the other API to stop the span.  
   
 Pros:
@@ -59,7 +68,9 @@ Cons:
 - We would add and force the user to use 2 APIs.  
 - If the user doesn't call the second API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.
 - We can't reliably map `Sentry.monitorFullyDrawn()` to the correct APM transaction, unless we force the user to call it in a specific callback, like `Activity.onActivityCreated()`.  
-4) Add `monitorFullyDrawn()` and `reportFullyDrawn()` to ISpan.  
+
+## 4. Add `monitorFullyDrawn()` and `reportFullyDrawn()` to ISpan. 
+
 The user gets access to the APM UI transaction by calling `Sentry.getSpan`, calls `span.monitorFullyDrawn()` and `span.reportFullyDrawn()`.  
 
 Pros:
@@ -71,7 +82,10 @@ Pros:
 Cons:
 - Extra APIs to call.  
 - Keeping a reference of transaction.  
-5) Add `reportFullyDrawn()` toISpan. The user gets access to the APM UI transaction by calling `Sentry.getSpan`, and calls `span.monitorFullyDrawn()`.  
+
+## 5. Add `reportFullyDrawn()` toISpan.
+
+The user gets access to the APM UI transaction by calling `Sentry.getSpan`, and calls `span.monitorFullyDrawn()`.  
 
 Pros:
 - We don't depend on Activity, making it usable on other platforms, too.  
@@ -82,7 +96,10 @@ Cons:
 - Extra APIs to call.  
 - Keeping a reference of transaction.
 - Not knowing when to wait for fully drawn.
-6) Hook into Android's new `FullyDrawnReporter` and use a callback from that.  
+
+## 6. Hook into Android's new `FullyDrawnReporter`
+
+We would use use a callback from that.  
 
 Pros:
 - Completely automatic and transparent to the user.  

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -30,7 +30,8 @@ At this point without the activity it was called on, we wouldn't know which span
 * [3. Sentry.monitorFullyDrawn() with UUID](#option-3)
 * [4. monitorFullyDrawn on ISpan](#option-3)
 * [5. reportFullyDrawn() on ISpan](#option-5)
-* [6. Hook into Android's `FullyDrawnReporter`](#option-6)
+* [6. reportFullyDrawn on ISpan with Option](#option-6)
+* [7. Hook into Android's `FullyDrawnReporter`](#option-7)
   
 These options were considered for Android, but the same apply to other SDKs, too.  
 
@@ -102,15 +103,36 @@ Add `monitorFullyDrawn()` and `reportFullyDrawn()` to ISpan. The user gets acces
 - Keeping a reference of transaction.
 
 
-## 5. reportFullyDrawn() on ISpan <a name="option-5"></a>
+## 5. reportFullyDrawn on ISpan <a name="option-5"></a>
 
 Add `reportFullyDrawn()` toISpan. The user gets access to the APM UI transaction by calling `Sentry.getSpan`, and calls `span.monitorFullyDrawn()`.  
 
-### Pros
+### Pros <a name="option-5-pros"></a>
 
 - We don't depend on Activity, making it usable on other platforms, too.  
 - Correlate fully drawn to correct APM transaction.  
 - User can add more spans via the same API Sentry.span.  
+
+### Cons <a name="option-5-cons"></a>
+
+1. Extra APIs to call.  
+2. Keeping a reference of a transaction.
+3. Not knowing when to wait for fully drawn.
+
+## 6. reportFullyDrawn on ISpan with Option <a name="option-6"></a>
+
+Same as Option 5. but with an option wether to wait for calling `reportFullyDrawn` or not. 
+The SDK would wait for a configurable timeout for the user to call `reportFullyDrawn`. If the user doesn't call the API the SDK adds a `ui.load.full_display` span with `deadline_exceeded`, and finishes the auto-generated transaction.
+If the user calls `reportFullyDrawn` and the option wether to wait for calling `reportFullyDrawn` or not is disabled, the SDK does nothing.
+
+### Pros
+
+- [Same Pros as option 5](#option-5-pros)
+- Knowing when to wait for fully drawn when option enabled.
+
+### Cons
+
+1. [Cons 1-2 of option 5](#option-5-cons)
 
 ### Cons
 
@@ -119,7 +141,7 @@ Add `reportFullyDrawn()` toISpan. The user gets access to the APM UI transaction
 - Not knowing when to wait for fully drawn.
 
 
-## 6. Hook into Android's `FullyDrawnReporter` <a name="option-6"></a>
+## 7. Hook into Android's `FullyDrawnReporter` <a name="option-7"></a>
 
 We would use use a callback from that.  
 

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -30,6 +30,7 @@ These options were considered for Android, but the same apply to other SDKs, too
   
 Pros:
 - This resembles the system API `Activity.reportFullyDrawn()`, making it immediate to use.  
+
 Cons:
 - We need the activity this API is called for, and passing an Activity instance to an API is not ideal.  
 - We need to add an API to `SentryAndroid`, instead of the `Sentry` class used everywhere else, due to Activity dependency.  
@@ -40,6 +41,7 @@ This API would return the span or a custom object to allow the user to finish it
   
 Pros:
 - We can flag the span when the API is called, so that if the user doesn't call the API, we know we can cancel it.  
+
 Cons:
 - We don't depend on Activity, making it usable on other platforms, too.  
 - Returning the span would allow the user to perform "dangerous" operations. We could solve this by returning a stripped interface to allow only the `finish()` method, or an entirely custom object.  
@@ -52,25 +54,30 @@ Pros:
 - We don't depend on Activity, making it usable on other platforms, too.  
 - We can flag the span when the API is called, so that if the user doesn't call the API, we know we can cancel it.  
 - We don't return any "dangerous" object to the user.  
+
 Cons:
 - We would add and force the user to use 2 APIs.  
 - If the user doesn't call the second API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.
 - We can't reliably map `Sentry.monitorFullyDrawn()` to the correct APM transaction, unless we force the user to call it in a specific callback, like `Activity.onActivityCreated()`.  
 4) Add `monitorFullyDrawn()` and `reportFullyDrawn()` to ISpan.  
 The user gets access to the APM UI transaction by calling `Sentry.getSpan`, calls `span.monitorFullyDrawn()` and `span.reportFullyDrawn()`.  
+
 Pros:
 - We don't depend on Activity, making it usable on other platforms, too.  
 - Correlate fully drawn to correct APM transaction.  
 - User can add more spans via the same API Sentry.span.  
 - Knowing when to wait for fully drawn.  
+
 Cons:
 - Extra APIs to call.  
 - Keeping a reference of transaction.  
 5) Add `reportFullyDrawn()` toISpan. The user gets access to the APM UI transaction by calling `Sentry.getSpan`, and calls `span.monitorFullyDrawn()`.  
+
 Pros:
 - We don't depend on Activity, making it usable on other platforms, too.  
 - Correlate fully drawn to correct APM transaction.  
 - User can add more spans via the same API Sentry.span.  
+
 Cons:
 - Extra APIs to call.  
 - Keeping a reference of transaction.

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -22,6 +22,7 @@ We have to add a new API to the SDK to allow the user to notify that the UI was 
 Also, we need the user to specify the span to finish through a parameter, as it cannot be done automatically.  
 E.g. Activity A starts -> Activity B starts -> Activity A finishes loading data and the API is called.  
 At this point without the activity it was called on, we wouldn't know which span to finish, because the activity B would be at the top of the stack.  
+  
 # Final Decision
   
 We decided to go with the simplest API possible, from the end user perspective.  
@@ -35,7 +36,6 @@ Furthermore, we will evaluate if the SDKs should automatically finish the `time-
 This consideration will be evaluated after getting feedbacks (or complains) from the users and after checking the feature adoption.  
   
 We are keeping the considered options as a reference.  
-  
   
 ## Options Considered
 

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -1,6 +1,6 @@
 - Start Date: 2022-12-16
 - RFC Type: feature
-- RFC PR: <link>
+- RFC PR: https://github.com/getsentry/rfcs/pull/46
 - RFC Status: draft
 
 # Summary

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -89,7 +89,6 @@ Pros:
 - We would know the activity that was drawn, so we'd know the span to finish.  
 
 Cons:
-- Would work for first launch of the first Activity only, as the documentation of `Activity.reportFullyDrawn` says `You can safely call this method any time after first launch as well, in which case it will simply be ignored.`  
 - Only available from `androidx.activity` library version 1.7, currently in alpha.  
 - This is not ideal for single activity apps, as it wouldn't work for fragments.  
 - Not knowing when to wait for fully drawn.  

--- a/text/0046-ttfd-automatic-transaction-span.md
+++ b/text/0046-ttfd-automatic-transaction-span.md
@@ -3,13 +3,13 @@
 - RFC PR: https://github.com/getsentry/rfcs/pull/46
 - RFC Status: draft
   
-# Summary. 
+# Summary 
   
 We want to provide a new span to the automatic UI transactions.  
 The TTFD (time-to-full-display) span is a way for the user to notify the SDK that the UI has been fully loaded.  
 That is, after all data is retrieved, either by database calls or rest APIs, and set into the UI.  
 We would create a new span to the UI automatic transactions to measure it, for all screens of the application.  
-This rfc is mostly about how we should design the new API.  
+This RFC is mostly about how we should design the new API.  
   
 # Motivation
 
@@ -27,8 +27,8 @@ At this point without the activity it was called on, we wouldn't know which span
   
 These options were considered for Android, but the same apply to other SDKs, too.  
 
-## 1. Add a `SentryAndroid.reportFullyDrawn(Activity)` static method.
-We would start the span automatically when an Activity is being created and we would finish it when the API is called.  
+## 1. SentryAndroid.reportFullyDrawn(Activity)
+Add a `SentryAndroid.reportFullyDrawn(Activity)` static method. We would start the span automatically when an Activity is being created and we would finish it when the API is called.  
   
 Pros:
 - This resembles the system API `Activity.reportFullyDrawn()`, making it obvious how to use.  
@@ -40,23 +40,23 @@ Cons:
 - If the user doesn't call the API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
 
 
-## 2. Add a `Sentry.monitorFullyDrawn()` API.
+## 2. Sentry.monitorFullyDrawn() with Span
 
-We would start the span automatically when an Activity is being created.  
+Add a `Sentry.monitorFullyDrawn()` API. We would start the span automatically when an Activity is being created.  
 This API would return the span or a custom object to allow the user to finish it autonomously.  
   
 Pros:
-- We can flag the span when the API is called, so that if the user doesn't call the API, we know we can cancel it.  
+- We can flag the span when the API is called, so that if the user doesn't call the API, we know we can cancel it. 
 
 Cons:
-- We don't depend on Activity, making it usable on other platforms, too.  
+ 
 - Returning the span would allow the user to perform "dangerous" operations. We could solve this by returning a stripped interface to allow only the `finish()` method, or an entirely custom object.  
 - If the user doesn't call the API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.  
 - We can't reliably map `Sentry.monitorFullyDrawn()` to the correct APM transaction, unless we force the user to call it in a specific callback, like `Activity.onActivityCreated()`.  
 
-## 3. Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(UUID)` API.
+## 3. Sentry.monitorFullyDrawn() with UUID
 
-We would start the span automatically when an Activity is being created.  
+Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(UUID)` API. We would start the span automatically when an Activity is being created.  
 This API would return a UUID used by the other API to stop the span.  
   
 Pros:
@@ -69,9 +69,9 @@ Cons:
 - If the user doesn't call the second API, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.
 - We can't reliably map `Sentry.monitorFullyDrawn()` to the correct APM transaction, unless we force the user to call it in a specific callback, like `Activity.onActivityCreated()`.  
 
-## 4. Add `monitorFullyDrawn()` and `reportFullyDrawn()` to ISpan. 
+## 4. monitorFullyDrawn on ISpan
 
-The user gets access to the APM UI transaction by calling `Sentry.getSpan`, calls `span.monitorFullyDrawn()` and `span.reportFullyDrawn()`.  
+Add `monitorFullyDrawn()` and `reportFullyDrawn()` to ISpan. The user gets access to the APM UI transaction by calling `Sentry.getSpan`, calls `span.monitorFullyDrawn()` and `span.reportFullyDrawn()`.  
 
 Pros:
 - We don't depend on Activity, making it usable on other platforms, too.  
@@ -83,9 +83,9 @@ Cons:
 - Extra APIs to call.  
 - Keeping a reference of transaction.  
 
-## 5. Add `reportFullyDrawn()` toISpan.
+## 5. reportFullyDrawn() on ISpan.
 
-The user gets access to the APM UI transaction by calling `Sentry.getSpan`, and calls `span.monitorFullyDrawn()`.  
+Add `reportFullyDrawn()` toISpan. The user gets access to the APM UI transaction by calling `Sentry.getSpan`, and calls `span.monitorFullyDrawn()`.  
 
 Pros:
 - We don't depend on Activity, making it usable on other platforms, too.  
@@ -97,7 +97,7 @@ Cons:
 - Keeping a reference of transaction.
 - Not knowing when to wait for fully drawn.
 
-## 6. Hook into Android's new `FullyDrawnReporter`
+## 6. Hook into Android's `FullyDrawnReporter`
 
 We would use use a callback from that.  
 

--- a/text/XXXX-ttfd-automatic-transaction-span.md
+++ b/text/XXXX-ttfd-automatic-transaction-span.md
@@ -1,0 +1,54 @@
+- Start Date: 2022-12-16
+- RFC Type: feature
+- RFC PR: <link>
+- RFC Status: draft
+
+# Summary
+
+We want to provide a new span to the automatic ui transactions.
+The ttfd (time-to-full-display) span is a way for the user to notify the sdk that a ui has been fully loaded.
+That is, after all data is retrieved, either by database calls or rest apis, and set into the ui.
+We would create a new span to the ui automatic transactions to measure it, for all screens of the application.
+This rfc is mostly about how we should design the new api.
+
+# Motivation
+
+This is useful especially for mobile developers, but could also be useful for web.
+There is no reliable way to automatically detect when a ui is fully drawn, as the "fully drawn" concept itself is dependant upon the developer.
+
+# Background
+
+We have to add a new api to the sdk to allow the user to notify that a ui was fully drawn.
+
+# Options Considered
+
+These options were considered for Android, but the same apply to other sdks, too.
+1) Add a `SentryAndroid.reportFullyDrawn(Activity)` static method. We would start the span automatically when an Activity is being created and we would finish it when the api is called.
+Pros: This resembles the system api `Activity.reportFullyDrawn()`, making it immediate to use.
+Cons:
+ - We need the activity this api is called for, and passing an Activity instance to an api is not ideal.
+E.g. Activity A starts -> Activity B starts -> Activity A finishes loading data and the api is called.
+At this point without the activity it was called on, we wouldn't know which span to finish, because the activity B would be at the top of the stack.
+ - We need to add an api to `SentryAndroid`, instead of the `Sentry` class used everywhere else, due to Activity dependency.
+ - This is not ideal for single activity apps, as it wouldn't work for fragments
+ - If the user doesn't call the api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.
+2) Add a `Sentry.monitorFullyDrawn()` api. We would start the span automatically when an Activity is being created. 
+This api would return the span or a custom object to allow the user to finish it autonomously.
+Pros: We can flag the span when the api is called, so that if the user doesn't call the api, we know we can cancel it
+Cons: 
+- Returning the span would allow the user to perform "dangerous" operations. We could solve this by returning a stripped interface to allow only the `finish()` method, or an entirely custom object.
+- If the user doesn't call the api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span. 
+3) Add a `Sentry.monitorFullyDrawn()` and a `Sentry.reportFullyDrawn(ISpan)` api. We would start the span automatically when an Activity is being created. 
+This api would return a uid used by the other api to stop the span.
+Pros: 
+- We can flag the span when the api is called, so that if the user doesn't call the api, we know we can cancel it
+- We don't return any "dangerous" object to the user
+Cons: 
+- We would add and force the user to use 2 apis
+- If the user doesn't call the second api, we would have a span that runs forever. We would have to add a timeout to automatically cancel the span.
+
+# Unresolved questions
+
+- How long should the timeout be? The Facebook app developers consider a "bad start" a ttfd of 2.5 seconds or more, or an unsuccessful start. 
+This is only for the first screen, as the other screens are usually faster.
+https://android-developers.googleblog.com/2021/11/improving-app-startup-facebook-app.html


### PR DESCRIPTION
We want to provide a new span to the automatic ui transactions.
The ttfd (time-to-full-display) span is a way for the user to notify the sdk that a ui has been fully loaded.
That is, after all data is retrieved, either by database calls or rest apis, and set into the ui.
We would create a new span to the ui automatic transactions to measure it, for all screens of the application.
This rfc is mostly about how we should design the new api.

Also please edit the "Rendered RFC" link so one can quickly get to the rendered markdown file.

[Rendered RFC](https://github.com/getsentry/rfcs/blob/ui-transaction-ttfd-span/text/0046-ttfd-automatic-transaction-span.md)
