### PR TITLE
feat(rfc): Introduce profiling context

### DIFF
--- a/text/0047-introduce-profile-context.md
+++ b/text/0047-introduce-profile-context.md
@@ -12,9 +12,9 @@ transactions so we can easily relate a group of transactions back to the respect
 
 We already have a way to relate a group of profiles back to the respective transaction. And up to
 this point, we have been using this relationship to map single transaction at a time to the
-respective profile. This is now insufficient as we would like to be able to relate a group of
-transactions back to the respective profile. This is to enable various touch points into profiling
-in the existing performance product.
+respective profile. This is now insufficient as we would like to be able to relate a set of
+transaction ids back to the respective profile ids. This is to enable various touch points into
+profiling in the existing performance product.
 
 The intended use cases include
 

--- a/text/0047-introduce-profile-context.md
+++ b/text/0047-introduce-profile-context.md
@@ -34,7 +34,7 @@ Performance to Profiling and vice versa.
 
 ## SDK
 
-### Option A: Add a new context type
+### Add a new context type
 
 Introduce a key in the transaction payload under contexts called `profile` to include information
 related to the profile.
@@ -45,22 +45,6 @@ related to the profile.
   "contexts": {
     ...,
     "profile": {
-      "profile_id": "<id>"
-    }
-  }
-}
-```
-
-### Option B: Use the existing trace context
-
-Use the existing trace context and add a new key for the `profile_id`.
-
-```json
-{
-  ...,
-  "contexts": {
-    ...,
-    "trace": {
       "profile_id": "<id>"
     }
   }

--- a/text/0047-introduce-profile-context.md
+++ b/text/0047-introduce-profile-context.md
@@ -1,0 +1,110 @@
+- Start Date: 2022-12-20
+- RFC Type: feature
+- RFC PR: https://github.com/getsentry/rfcs/pull/47
+- RFC Status: draft
+
+# Summary
+
+We want to introduce the concept of a profiling context, much like a tracing context, starting with
+transactions so we can easily relate a group of transactions back to the respective profile.
+
+# Motivation
+
+We already have a way to relate a group of profiles back to the respective transaction. And up to
+this point, we have been using this relationship to map single transaction at a time to the
+respective profile. This is now insufficient as we would like to be able to relate a group of
+transactions back to the respective profile. This is to enable various touch points into profiling
+in the existing performance product.
+
+The intended use cases include
+
+- fetching a list of transaction with the profile ID
+- filtering transactions to only those that have a profile
+
+# Background
+
+Profiles will be closely associated to transactions and creating this relation will enable us to
+build a richer integration between the Performance and Profiling products.
+
+Since the Profiling product will be initially tied to the Performance product, we want to ensure
+that there is a smooth integration through various touch points to allow users to navigate from
+Performance to Profiling and vice versa.
+
+# Options Considered
+
+## SDK
+
+### Option A: Add a new context type
+
+Introduce a key in the transaction payload under contexts called `profile` to include information
+related to the profile.
+
+```json
+{
+  ...,
+  "contexts": {
+    ...,
+    "profile": {
+      "profile_id": "<id>"
+    }
+  }
+}
+```
+
+### Option B: Use the existing trace context
+
+Use the existing trace context and add a new key for the `profile_id`.
+
+```json
+{
+  ...,
+  "contexts": {
+    ...,
+    "trace": {
+      "profile_id": "<id>"
+    }
+  }
+}
+```
+
+## Storage
+
+To support querying for this relationship, we have to store the profile ID, extracted from the
+profile context set by the SDK, on the existing transactions dataset. The types of queries we want
+to do are as follows:
+
+1. Selecting the profile ID
+2. Selecting rows that have a profile ID since not all transactions will have a profile
+3. Selecting a transaction with a specific profile ID (this use case is less common)
+
+### Option A: Add a new column to the transactions dataset
+
+The new `profile_id` column will have type `Nullable(UUID)`. The queries would roughly look like
+
+1. `SELECT profile_id FROM transactions_local`
+2. `SELECT ... FROM transactions_local WHERE isNotNull(profile_id)`
+3. `SELECT ... FROM transactions_local WHERE profile_id = "<id>"`
+
+### Option B: Use the contexts columns on the transactions dataset
+
+The `profile_id` will be added to the existing array columns for contexts. The queries would roughly
+look like
+
+1. `SELECT contexts.value[indexOf(contexts.key, "profile_id")] FROM ...`
+2. `SELECT ... FROM ... WHERE has(contexts.key, "profile_id")`
+3. `SELECT ... FROM ... WHERE contexts.value[indexOf(contexts.key, "profile_id")] = "<id>"`
+
+# Drawbacks
+
+## Option A:
+
+1. Have to add a new column to the transactions dataset
+
+## Option B:
+
+1. Is there bloom filter index on contexts? Will it be performant enough?
+
+# Unresolved questions
+
+- Which option should we use for storing the profile ID on the transaction?
+- The relationship between errors and profiles are out of scope for this RFC.

--- a/text/0047-introduce-profile-context.md
+++ b/text/0047-introduce-profile-context.md
@@ -34,7 +34,7 @@ Performance to Profiling and vice versa.
 
 ## SDK
 
-### Option A: Add a new context type
+### Option A: Add a new context type (Chosen)
 
 Introduce a key in the transaction payload under contexts called `profile` to include information
 related to the profile.
@@ -51,7 +51,7 @@ related to the profile.
 }
 ```
 
-### Option B: Use the existing trace context
+### Option B: Use the existing trace context (Dropped)
 
 Use the existing trace context and add a new key for the `profile_id`.
 
@@ -77,7 +77,7 @@ to do are as follows:
 2. Selecting rows that have a profile ID since not all transactions will have a profile
 3. Selecting a transaction with a specific profile ID (this use case is less common)
 
-### Option A: Add a new column to the transactions dataset
+### Option A: Add a new column to the transactions dataset (Chosen)
 
 The new `profile_id` column will have type `Nullable(UUID)`. The queries would roughly look like
 
@@ -85,7 +85,7 @@ The new `profile_id` column will have type `Nullable(UUID)`. The queries would r
 2. `SELECT ... FROM transactions_local WHERE isNotNull(profile_id)`
 3. `SELECT ... FROM transactions_local WHERE profile_id = "<id>"`
 
-### Option B: Use the contexts columns on the transactions dataset
+### Option B: Use the contexts columns on the transactions dataset (Dropped)
 
 The `profile_id` will be added to the existing array columns for contexts. The queries would roughly
 look like

--- a/text/0047-introduce-profile-context.md
+++ b/text/0047-introduce-profile-context.md
@@ -1,7 +1,7 @@
 - Start Date: 2022-12-20
 - RFC Type: feature
 - RFC PR: https://github.com/getsentry/rfcs/pull/47
-- RFC Status: draft
+- RFC Status: approved
 
 # Summary
 

--- a/text/0047-introduce-profile-context.md
+++ b/text/0047-introduce-profile-context.md
@@ -34,7 +34,7 @@ Performance to Profiling and vice versa.
 
 ## SDK
 
-### Add a new context type
+### Option A: Add a new context type
 
 Introduce a key in the transaction payload under contexts called `profile` to include information
 related to the profile.
@@ -45,6 +45,22 @@ related to the profile.
   "contexts": {
     ...,
     "profile": {
+      "profile_id": "<id>"
+    }
+  }
+}
+```
+
+### Option B: Use the existing trace context
+
+Use the existing trace context and add a new key for the `profile_id`.
+
+```json
+{
+  ...,
+  "contexts": {
+    ...,
+    "trace": {
       "profile_id": "<id>"
     }
   }


### PR DESCRIPTION
Today, a profile contains a transaction ID to indicate the transaction that occurred within it. We would like to create the inverse relationship from a transaction to a profile to enable queries that were not feasible using only the relationship from profile to a transaction.

[Rendered RFC](https://github.com/getsentry/rfcs/blob/txiao/feat/introduce-profiling-context/text/0047-introduce-profile-context.md)
