### PR TITLE
fix(readme): add unlinked rfcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ This repository contains RFCs and DACIs. Lost?
 - [0036-auto-instrumentation-ui-thread](text/0036-auto-instrumentation-ui-thread.md): auto-instrumentation UI thread
 - [0037-anr-rates](text/0037-anr-rates.md): Calculating accurate ANR rates
 - [0038-scrubbing-sensitive-data](text/0038-scrubbing-sensitive-data.md): Scrubbing sensitive data - how to improve
-- [0039-sdks-report-file-IO-on-main-thread](text/0039-sdks-report-file-IO-on-main-thread): SDKs report file I/O on the main thread
+- [0039-sdks-report-file-IO-on-main-thread](text/0039-sdks-report-file-IO-on-main-thread.md): SDKs report file I/O on the main thread
 - [0042-gocd-succeeds-freight-as-our-cd-solution](text/0042-gocd-succeeds-freight-as-our-cd-solution.md): Plan to replace freight with GoCD
+- [0048-move-replayid-out-of-tags](text/0048-move-replayid-out-of-tags.md): Plan to replace freight with GoCD


### PR DESCRIPTION
adds unlinked rfcs to readme. should make this a required on CI at some point