### PR TITLE
rfc(feature): Continue trace over process boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ This repository contains RFCs and DACIs. Lost?
 - [0047-introduce-profile-context](text/0047-introduce-profile-context.md): Add Profile Context
 - [0048-move-replayid-out-of-tags](text/0048-move-replayid-out-of-tags.md): Plan to replace freight with GoCD
 - [0063-sdk-crash-monitoring](text/0063-sdk-crash-monitoring.md): SDK Crash Monitoring
+- [0071-continue-trace-over-process-boundaries](text/0071-continue-trace-over-process-boundaries.md): Continue trace over process boundaries

--- a/text/0071-continue-trace-over-process-boundaries.md
+++ b/text/0071-continue-trace-over-process-boundaries.md
@@ -31,7 +31,7 @@ See Appendix A if you want to know how this works in the Python SDK.
 
 # Decision
 
-We will implement Option A.
+We will implement **Option A**.
 
 In the [develop docs](https://develop.sentry.dev/) a specification of this RFC will be added and afterwards it will be first implemented in Python.
 

--- a/text/0071-continue-trace-over-process-boundaries.md
+++ b/text/0071-continue-trace-over-process-boundaries.md
@@ -35,7 +35,7 @@ See Appendix A if you want to know how this works in the Python SDK.
 
 ### Retrieving tracing information via environment variables:
 
-When the SDK starts up it reads an environment variable `SENTRY_TRACING_USE_ENVIRONMENT` (defaults to `False`).
+When the SDK starts up it reads an environment variable `SENTRY_TRACING_USE_ENVIRONMENT` (defaults to `True`).
 If `SENTRY_TRACING_USE_ENVIRONMENT` is set to `true` (or `true|True|TRUE|yes|Yes|YES|y|1|on`) then the SDK reads the following environment variables:
 
 - `SENTRY_TRACING_BAGGAGE` (similar to `baggage` HTTP header)
@@ -76,9 +76,9 @@ After the values are read from the files, the same considerations as in Option A
 
 Main differences from Option A:
 
-* Using files, tracing information can be passed not only from a parent process to a child process, but also between processes that don't have direct parent-child relationships.
-* Files used for transport can be updated by any other process (as far as filesystem permissions allow), and the SDK can technically re-read the file multiple times during the lifetime of the host application. However, I don't have a good use case for this right now.
-* Message passing via files is generally more cumbersome and might have performance/reliability drawbacks, depending on the type of file (plain file, named pipe) and the backing filesystem.
+- Using files, tracing information can be passed not only from a parent process to a child process, but also between processes that don't have direct parent-child relationships.
+- Files used for transport can be updated by any other process (as far as filesystem permissions allow), and the SDK can technically re-read the file multiple times during the lifetime of the host application. However, I don't have a good use case for this right now.
+- Message passing via files is generally more cumbersome and might have performance/reliability drawbacks, depending on the type of file (plain file, named pipe) and the backing filesystem.
 
 # Drawbacks
 

--- a/text/0071-continue-trace-over-process-boundaries.md
+++ b/text/0071-continue-trace-over-process-boundaries.md
@@ -89,6 +89,12 @@ Main differences from Option A:
 - Should we create a new `transaction_info.source` for this kind of transactions that span one execution of a process?
 - We probably need a flag on a transaction that says "do not emit me" but do consider me sampled (to avoid charging customers unnecessary transactions). This is out of scope for this RFC, but will be handled in a separate RFC.
 
+# Decision
+
+We will implement Option A.
+
+In the [develop docs](https://develop.sentry.dev/) a specification of this RFC will be added and afterwards it will be first implemented in Python.
+
 # Appendix A
 
 How trace propagation is working in the Python SDK right now:

--- a/text/0071-continue-trace-over-process-boundaries.md
+++ b/text/0071-continue-trace-over-process-boundaries.md
@@ -82,13 +82,12 @@ Main differences from Option A:
 
 # Drawbacks
 
-Because the serialization format of the bagagge (and thus the dynamic sampling context) stays the same, just the carrier is a new one, it should be 100% compatible to other integrations and will not break dynamic sampling.
-
-So: No drawbacks.
+- Because the serialization format of the bagagge (and thus the dynamic sampling context) stays the same, just the carrier is a new one, it should be 100% compatible to other integrations and will not break dynamic sampling. **So: No drawbacks.**
 
 # Unresolved questions
 
 - Should we create a new `transaction_info.source` for this kind of transactions that span one execution of a process?
+- We probably need a flag on a transaction that says "do not emit me" but do consider me sampled (to avoid charging customers unnecessary transactions). This is out of scope for this RFC, but will be handled in a separate RFC.
 
 # Appendix A
 

--- a/text/0071-continue-trace-over-process-boundaries.md
+++ b/text/0071-continue-trace-over-process-boundaries.md
@@ -1,7 +1,7 @@
 - Start Date: 2023-02-01
 - RFC Type: feature
 - RFC PR: https://github.com/getsentry/rfcs/pull/71
-- RFC Status: draft
+- RFC Status: approved
 
 # Summary
 
@@ -28,6 +28,12 @@ A few integrations (for example job queues) use queue specific meta data fields 
 The trace information can also be injected into rendered HTML as a <meta> HTML tag.
 
 See Appendix A if you want to know how this works in the Python SDK.
+
+# Decision
+
+We will implement Option A.
+
+In the [develop docs](https://develop.sentry.dev/) a specification of this RFC will be added and afterwards it will be first implemented in Python.
 
 # Options Considered
 
@@ -88,12 +94,6 @@ Main differences from Option A:
 
 - Should we create a new `transaction_info.source` for this kind of transactions that span one execution of a process?
 - We probably need a flag on a transaction that says "do not emit me" but do consider me sampled (to avoid charging customers unnecessary transactions). This is out of scope for this RFC, but will be handled in a separate RFC.
-
-# Decision
-
-We will implement Option A.
-
-In the [develop docs](https://develop.sentry.dev/) a specification of this RFC will be added and afterwards it will be first implemented in Python.
 
 # Appendix A
 

--- a/text/0071-continue-trace-over-process-boundaries.md
+++ b/text/0071-continue-trace-over-process-boundaries.md
@@ -1,0 +1,35 @@
+- Start Date: 2023-02-01
+- RFC Type: feature
+- RFC PR: https://github.com/getsentry/rfcs/pull/71
+- RFC Status: draft
+
+# Summary
+
+One paragraph explanation of the feature or document purpose.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Background
+
+The reason this decision or document is required. This section might not always exist.
+
+# Supporting Data
+
+[Metrics to help support your decision (if applicable).]
+
+# Options Considered
+
+If an RFC does not know yet what the options are, it can propose multiple options. The
+preferred model is to propose one option and to provide alternatives.
+
+# Drawbacks
+
+Why should we not do this? What are the drawbacks of this RFC or a particular option if
+multiple options are presented.
+
+# Unresolved questions
+
+- What parts of the design do you expect to resolve through this RFC?
+- What issues are out of scope for this RFC but are known?

--- a/text/0071-continue-trace-over-process-boundaries.md
+++ b/text/0071-continue-trace-over-process-boundaries.md
@@ -5,8 +5,9 @@
 
 # Summary
 
-To make it easier to continue a trace over process boundaries (think of one program starting another one, like cron jobs)
-It should be possible that the SDK on startup can fetch data from the environment variables (similar like we do when fetching trace context from http headers) and then create a "root transaction" that is attached to that trace and also continues the trace on outgoing requests.
+To make it possible to continue a trace over process boundaries (think of one program starting another one)
+For this to work we will use environment variables as the carrier.
+An SDK should be able to fetch tracing data from environment variables on `init()` to continue a trace started in another process.
 
 # Motivation
 
@@ -21,7 +22,7 @@ The `sentry-cli` call starts a trace (so it is the head of trace) and the Sentry
 ## Existing trace propagation mechanism
 
 Trace propagation is: giving trace information from one service (the first service, or head of trace) to a second service, so that the second service can create transactions that are attached to the trace created in the first service.
-In most cases the trace information is propagated through two HTTP headers (`sentry-trace` and `baggage`).
+In most cases we use HTTP as the carrier for trace information. The information is propagated through two HTTP headers (`sentry-trace` and `baggage`).
 A few integrations (for example job queues) use queue specific meta data fields for propagating trace information. (but those implementations only propagate `sentry-trace` and maybe the legacy `tracestate` that will be rmeoved, but NOT `baggage` so some information is lost here.)
 The trace information can also be injected into rendered HTML as a <meta> HTML tag.
 
@@ -34,22 +35,21 @@ See Appendix A if you want to know how this works in the Python SDK.
 ### Retrieving tracing information via environment variables:
 
 When the SDK starts up it reads an environment variable `SENTRY_TRACING_USE_ENVIRONMENT` (defaults to `False`).
-If `SENTRY_TRACING_USE_ENVIRONMENT` is set to `true` (or `true|True|TRUE|1|on|yes|y`) then the SDK reads the following environment variables:
+If `SENTRY_TRACING_USE_ENVIRONMENT` is set to `true` (or `true|True|TRUE|yes|Yes|YES|y|1|on`) then the SDK reads the following environment variables:
 
-- `SENTRY_TRACING_BAGGAGE`
-- `SENTRY_TRACING_SENTRY_TRACE`
+- `SENTRY_TRACING_BAGGAGE` (similar to `baggage` HTTP header)
+- `SENTRY_TRACING_SENTRY_TRACE` (similar to `sentry-trace` HTTP header)
 
 The environment variables contain the same strings that the respecitve HTTP headers would contain.
-The SDK parses the string values from the environment variables and stores them in the current scope.
-TODO: is the scope where this should live? Or just some local (or global) variable?
+The SDK parses the string values from the environment variables and stores. SDKs can decide where the what to store this tracing information.
 
 To successfully attach a transaction to an existing trace at least `SENTRY_TRACING_SENTRY_TRACE` must have data.
 
-For dynamic sampling not to break, `SENTRY_TRACING_BAGGAGE` needs to include all information of the dynamic sampling context. The parsed baggage must not be changed.
+For dynamic sampling not to break, `SENTRY_TRACING_BAGGAGE` needs to include all information of the dynamic sampling context. The tracing information parsed from this must not be changed.
 
-When `SENTRY_TRACING_USE_ENVIRONMENT` is set to true during startup also a so called "Root Transaction" should be created automatically. It should include all the trace information from the scope and should be finished just before the process ends.
+When `SENTRY_TRACING_USE_ENVIRONMENT` is set to `true` during startup also a so called "Root Transaction" should be created automatically. It should include all the trace information from the parsed tracing information and should be finished just before the process ends.
 
-TODO: Maybe we should create a new transaction source for this kind of root transactions?
+TODO: Maybe we should create a new `transaction_info.source` for this kind of root transactions?
 
 ### Creating tracing information on process start up
 
@@ -61,16 +61,15 @@ See [Dynamic Sampling Context Payloads](https://develop.sentry.dev/sdk/performan
 
 ### Propagating/sending tracing information via environment variables:
 
-The integrations that patch functions that are used for spawning new processes (`StdlibIntegration` in Python) should be changed so they grab the tracing information from the scope (if any) and set them in the environment variables (`SENTRY_TRACING_BAGGAGE`, `SENTRY_TRACING_SENTRY_TRACE`) for the newly spawned process. The variable `SENTRY_TRACING_USE_ENVIRONMENT` should also be set to `true` so the receiving process is picking up the information.
+The integrations that patch functions that are used for spawning new processes (`StdlibIntegration` in Python) should be changed so they use the parsed tracing information (if any) and serialize it to the environment variables (`SENTRY_TRACING_BAGGAGE`, `SENTRY_TRACING_SENTRY_TRACE`) for the newly spawned process. The variable `SENTRY_TRACING_USE_ENVIRONMENT` should also be set to `true` so the receiving process is picking up the information.
 
 # Drawbacks
 
-TODO: Why should we not do this? What are the drawbacks of this RFC or a particular option if multiple options are presented.
+Because the serialization format of the bagagge (and thus the dynamic sampling context) stays the same, just the carrier is a new one, it should be 100% compatible to other integrations and will not break dynamic sampling.
 
 # Unresolved questions
 
-- TODO: What parts of the design do you expect to resolve through this RFC?
-- TODO: What issues are out of scope for this RFC but are known?
+- Should create a new `transaction_info.source` for this kind of transactions that span one execution of a process?
 
 # Appendix A
 

--- a/text/0071-continue-trace-over-process-boundaries.md
+++ b/text/0071-continue-trace-over-process-boundaries.md
@@ -5,9 +5,7 @@
 
 # Summary
 
-To make it possible to continue a trace over process boundaries (think of one program starting another one)
-For this to work we will use environment variables as the carrier.
-An SDK should be able to fetch tracing data from environment variables on `init()` to continue a trace started in another process.
+To make it possible to continue a trace over process boundaries (think of one program starting another one) For this to work we will use environment variables as the carrier. An SDK should be able to fetch tracing data from environment variables on `init()` to continue a trace started in another process.
 
 # Motivation
 
@@ -22,8 +20,11 @@ The `sentry-cli` call starts a trace (so it is the head of trace) and the Sentry
 ## Existing trace propagation mechanism
 
 Trace propagation is: giving trace information from one service (the first service, or head of trace) to a second service, so that the second service can create transactions that are attached to the trace created in the first service.
+
 In most cases we use HTTP as the carrier for trace information. The information is propagated through two HTTP headers (`sentry-trace` and `baggage`).
+
 A few integrations (for example job queues) use queue specific meta data fields for propagating trace information. (but those implementations only propagate `sentry-trace` and maybe the legacy `tracestate` that will be rmeoved, but NOT `baggage` so some information is lost here.)
+
 The trace information can also be injected into rendered HTML as a <meta> HTML tag.
 
 See Appendix A if you want to know how this works in the Python SDK.
@@ -67,9 +68,11 @@ The integrations that patch functions that are used for spawning new processes (
 
 Because the serialization format of the bagagge (and thus the dynamic sampling context) stays the same, just the carrier is a new one, it should be 100% compatible to other integrations and will not break dynamic sampling.
 
+So: No drawbacks.
+
 # Unresolved questions
 
-- Should create a new `transaction_info.source` for this kind of transactions that span one execution of a process?
+- Should we create a new `transaction_info.source` for this kind of transactions that span one execution of a process?
 
 # Appendix A
 

--- a/text/0071-continue-trace-over-process-boundaries.md
+++ b/text/0071-continue-trace-over-process-boundaries.md
@@ -5,31 +5,88 @@
 
 # Summary
 
-One paragraph explanation of the feature or document purpose.
+To make it easier to continue a trace over process boundaries (think of one program starting another one, like cron jobs)
+It should be possible that the SDK on startup can fetch data from the environment variables (similar like we do when fetching trace context from http headers) and then create a "root transaction" that is attached to that trace and also continues the trace on outgoing requests.
 
 # Motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
+The Sentry "Cron Monitors" feature suggests that one can add something like this to the crontab:
+
+`10 * * * *   sentry-cli monitor run <monitor_id> -- python my_cron_job.py`.
+
+The `sentry-cli` call starts a trace (so it is the head of trace) and the Sentry SDK in `my_cron_job.py` should connect it's transactions to that trace.
 
 # Background
 
-The reason this decision or document is required. This section might not always exist.
+## Existing trace propagation mechanism
 
-# Supporting Data
+Trace propagation is: giving trace information from one service (the first service, or head of trace) to a second service, so that the second service can create transactions that are attached to the trace created in the first service.
+In most cases the trace information is propagated through three HTTP headers (`sentry-trace`, `baggage` and `tracestate`).
+A few integrations (for example job queues) use queue specific meta data fields for propagating trace information. (but those implementations only propagate `sentry-trace` and `tracestate`, NOT `baggage` so some information is lost here.)
+The trace information can also be injected into rendered HTML as a <meta> HTML tag.
 
-[Metrics to help support your decision (if applicable).]
+See Appendix A if you want to know how this works in the Python SDK.
 
 # Options Considered
 
-If an RFC does not know yet what the options are, it can propose multiple options. The
-preferred model is to propose one option and to provide alternatives.
+## Option A)
+
+### Retrieving tracing information via environment variables:
+
+When the SDK starts up it reads an environment variable `SENTRY_TRACING_USE_ENVIRONMENT` (defaults to `False`).
+If `SENTRY_TRACING_USE_ENVIRONMENT` is set to `true` (or `true|True|TRUE|1|on|yes|y`) then the SDK reads the following environment variables:
+
+- `SENTRY_TRACING_BAGGAGE`
+- `SENTRY_TRACING_SENTRY_TRACE`
+- `SENTRY_TRACING_TRACESTATE`
+
+The environment variables contain the same strings that the respecitve HTTP headers would contain.
+The SDK parses the string values from the environment variables and stores them in the current scope.
+TODO: is the scope where this should live? Or just some local (or global) variable?
+
+To successfully attach a transaction to an existing trace at least `SENTRY_TRACING_SENTRY_TRACE` must have data.
+
+For dynamic sampling not to break, `SENTRY_TRACING_BAGGAGE` needs to include all information of the dynamic sampling context. The parsed baggage must not be changed.
+
+When `SENTRY_TRACING_USE_ENVIRONMENT` is set to true during startup also a so called "Root Transaction" should be created automatically. It should include all the trace information from the scope and should be finished just before the process ends.
+
+TODO: Maybe we should create a new transaction source for this kind of root transactions?
+
+### Creating tracing information on process start up
+
+If `SENTRY_TRACING_USE_ENVIRONMENT` is set to `true` and no information can be found in `SENTRY_TRACING_BAGGAGE`, `SENTRY_TRACING_SENTRY_TRACE` or `SENTRY_TRACING_TRACESTATE` then the current process is the head of trace and a dynamic sampling context should be created.
+
+See [Unified Propagation Mechanism](https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#unified-propagation-mechanism) for details.
+
+See [Dynamic Sampling Context Payloads](https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#payloads) to see what data needs to be included in the dynamic sampling context.
+
+### Propagating/sending tracing information via environment variables:
+
+The integrations that patch functions that are used for spawning new processes (`StdlibIntegration` in Python) should be changed so they grab the tracing information from the scope (if any) and set them in the environment variables (`SENTRY_TRACING_BAGGAGE`, `SENTRY_TRACING_SENTRY_TRACE`, `SENTRY_TRACING_TRACESTATE`) for the newly spawned process. The variable `SENTRY_TRACING_USE_ENVIRONMENT` should also be set to `true` so the receiving process is picking up the information.
 
 # Drawbacks
 
-Why should we not do this? What are the drawbacks of this RFC or a particular option if
-multiple options are presented.
+TODO: Why should we not do this? What are the drawbacks of this RFC or a particular option if multiple options are presented.
 
 # Unresolved questions
 
-- What parts of the design do you expect to resolve through this RFC?
-- What issues are out of scope for this RFC but are known?
+- TODO: What parts of the design do you expect to resolve through this RFC?
+- TODO: What issues are out of scope for this RFC but are known?
+
+# Appendix A
+
+How trace propagation is working in the Python SDK right now:
+
+When a request from another service is received a transaction is created. (So each request-response cycle is a transaction).
+The process of creating a transaction that attaches to an existing trace received from the calling service is done as follows:
+
+- data from the `baggage` header is parsed. If it contains values with a `sentry-` prefix the parsed baggage is frozen (marked as immutable).
+- data from the `sentry-trace` header is parsed. (`trace_id`, `parent_span_id` and `parent_sampled`) If this header exists and contains values the parsed baggage from step is is frozen (marked as immutable).
+- data from the `tracestate` header is parsed. (`sentry_tracestate` and `third_party_tracestate`).
+- With all this information a new transaction is created.
+- If an outgoing request is done this tracing information is attached to the request as HTTP headers, thus propagated.
+- There are the options `propagate_traces` and `propagate_tracestate` that can turn off the propagation of traces (but not yet implemented in all integrations, so some integrations ignore them).
+
+This should adhere to the [Unified Propagation Mechanism](https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#unified-propagation-mechanism).
+
+Currently every integration itself takes care of parsing tracing information and attaching it to Transactions or outgoing requests.


### PR DESCRIPTION
To make it possible to continue a trace over process boundaries (think of one program starting another one) For this to work we will use environment variables as the carrier. 

[Rendered RFC](https://github.com/getsentry/rfcs/blob/rfc/continue-trace-over-process-boundaries/text/0071-continue-trace-over-process-boundaries.md)