### PR TITLE
rfc(feature): Kafka schema registry

### DIFF
--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -67,10 +67,10 @@ topic: events
 schemas:
 	- version: 1
 	type: json
-    resource: events.schema.json
-    - version: 2
+	resource: events.schema.json
+	- version: 2
 	type: avro
-    resource: events_v2.avsc
+	resource: events_v2.avsc
 ```
 
 In this example scenario, we decided to make a change to schemas on the “events” topic. The `events.schema.json` and `events_v2.avsc` files must be present. The version bump is only necessary for major breaking changes of the schema (like changing the encoding). Most changes should be done in backward compatible manner, and keep the same version number even if the schema changes.

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -65,12 +65,12 @@ Topic data will be stored as yaml. For example:
 ```
 topic: events
 schemas:
-  - version: 1
-  type: json
-  resource: events.schema.json
-  - version: 2
-  type: avro
-  resource: events_v2.avsc
+- version: 1
+type: json
+    resource: events.schema.json
+    - version: 2
+    type: avro
+    resource: events_v2.avsc
 ```
 
 In this example scenario, we decided to make a change to schemas on the “events” topic. The `events.schema.json` and `events_v2.avsc` files must be present. The version bump is only necessary for major breaking changes of the schema (like changing the encoding). Most changes should be done in backward compatible manner, and keep the same version number even if the schema changes.

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -21,6 +21,7 @@ The goals of the centralized schema repository are to:
 - provide more stability by enforcing backward compatibility of changes via automation
 - explicitly enumerate ownership of schemas
 - make it easier for consumers to identify and reject bad messages without pausing the whole pipeline
+- provide examples of messages for each schema type, which would help with writing consumer tests
 
 # Supporting Data
 

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -68,17 +68,25 @@ Topic data will be stored as yaml. For example:
 topic: events
 schemas:
     - version: 1
+    compatibility_mode: backward
     type: json
     resource: events.schema.json
     - version: 2
+    compatibility_mode: none
     type: avro
     resource: events_v2.avsc
 ```
 
-In this example scenario, we decided to make a change to schemas on the “events” topic. The `events.schema.json` and `events_v2.avsc` files must be present. The version bump is only necessary for major breaking changes of the schema (like changing the encoding). Most changes should be done in backward compatible manner, and keep the same version number even if the schema changes.
+In this example scenario, we decided to make a change to schemas on the “events” topic. The `events.schema.json` and `events_v2.avsc` files must be present.
 
-**Data governance**
-The schemas repository will have checks in place to ensure schemas are valid and non backwards compatible changes are not being introduced with a same version number.
+**Compatibility modes:**
+Each schema version defines it's compatibility mode. There will be 2 to start but more can be added if we want to change or tighten the rules.
+
+- `none` - Any changes are allowed. Generally used if a feature is in dev to allow for fast iteration and breaking changes.
+- `backward` - Allows adding optional fields, removing optional fields, and changing from optional to required and required to optional. Required field cannot be added at once, it must be split into 2 separate releases.
+
+If `backward` is selected, CI in the schemas repository will ensure changes that are not allowed are not being introduced with a same version number
+
 
 ### **Option B (alternative, non-preferred option): Deploy a separate service**
 

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -63,6 +63,7 @@ v1_schema = get_schema(topic, version=1)
 ```
 
 **How schemas are stored:**
+
 Topic data will be stored as yaml. For example:
 
 ```
@@ -81,6 +82,7 @@ schemas:
 In this example scenario, we decided to make a change to schemas on the “events” topic. The `events.schema.json` and `events_v2.avsc` files must be present.
 
 **Compatibility modes:**
+
 Each schema version defines it's compatibility mode. There will be 2 to start but more can be added if we want to change or tighten the rules.
 
 - `none` - Any changes are allowed. Generally used if a feature is in dev to allow for fast iteration and breaking changes.

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -1,7 +1,7 @@
 - Start Date: 2023-02-01
 - RFC Type: feature
 - RFC PR: https://github.com/getsentry/sentry-kafka-schemas/pull/2
-- RFC Status: draft
+- RFC Status: approved
 
 # Summary
 

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -1,0 +1,35 @@
+- Start Date: 2023-02-01
+- RFC Type: feature
+- RFC PR: <link>
+- RFC Status: draft
+
+# Summary
+
+One paragraph explanation of the feature or document purpose.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Background
+
+The reason this decision or document is required. This section might not always exist.
+
+# Supporting Data
+
+[Metrics to help support your decision (if applicable).]
+
+# Options Considered
+
+If an RFC does not know yet what the options are, it can propose multiple options. The
+preferred model is to propose one option and to provide alternatives.
+
+# Drawbacks
+
+Why should we not do this? What are the drawbacks of this RFC or a particular option if
+multiple options are presented.
+
+# Unresolved questions
+
+- What parts of the design do you expect to resolve through this RFC?
+- What issues are out of scope for this RFC but are known?

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -52,7 +52,7 @@ schema = get_schema(topic)
 #   "version": 1,
 # 	"schema": {
 # 		"$schema": "http://json-schema.org/draft-07/schema#",
-#       "compatibility_mode": "backward",
+# 		"compatibility_mode": "backward",
 # 		"type": "object",
 # 		...
 # 	}

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -78,7 +78,7 @@ In this example scenario, we decided to make a change to schemas on the “event
 **Data governance**
 The schemas repository will have checks in place to ensure schemas are valid and non backwards compatible changes are not being introduced with a same version number.
 
-### **Option B (alternative, non-preferred option): Deploy a separate service **
+### **Option B (alternative, non-preferred option): Deploy a separate service**
 
 No library is provided. Clients fetch data from the schemas service and need to know how to parse the schema from the response by themselves. The schemas service could either be built from scratch or we could deploy an existing open source implementation such as Confluent schema registry.
 

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -29,7 +29,7 @@ Over the last quarter, we have seen many incidents related to schema disagreemen
 - Post process forwarder (INC-218)
 - Snuba’s transactions consumer (INC-210)
 - Super big consumers (INC-220)
-- Replays consumer (INC-281)
+- Replays consumer (INC-250, INC-281)
 
 Many of these incidents are P1. Since messages are in order, an invalid message often halts consumers and requires manual intervention. This is disruptive to both Sentry engineers and our users (it takes us much longer to recover).
 

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -1,6 +1,6 @@
 - Start Date: 2023-02-01
 - RFC Type: feature
-- RFC PR: n/a
+- RFC PR: https://github.com/getsentry/sentry-kafka-schemas/pull/2
 - RFC Status: draft
 
 # Summary

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -49,6 +49,7 @@ topic = "events"
 schema = get_schema(topic)
 # => {
 # 	"type": "json"
+#   "version": 1,
 # 	"schema": {
 # 		"$schema": "http://json-schema.org/draft-07/schema#",
 # 		"type": "object",

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -48,11 +48,11 @@ from sentry_kafka_schemas import get_schema
 topic = "events"
 schema = get_schema(topic)
 # => {
-# 	"type": "json"
 # 	"version": 1,
+# 	"type": "json"
+# 	"compatibility_mode": "backward",
 # 	"schema": {
 # 		"$schema": "http://json-schema.org/draft-07/schema#",
-# 		"compatibility_mode": "backward",
 # 		"type": "object",
 # 		...
 # 	}

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -62,15 +62,15 @@ v1_schema = get_schema(topic, version=1)
 **How schemas are stored:**
 Topic data will be stored as yaml. For example:
 
-```yaml
+```
 topic: events
 schemas:
-	- version: 1
-	type: json
-	resource: events.schema.json
-	- version: 2
-	type: avro
-	resource: events_v2.avsc
+  - version: 1
+  type: json
+  resource: events.schema.json
+  - version: 2
+  type: avro
+  resource: events_v2.avsc
 ```
 
 In this example scenario, we decided to make a change to schemas on the “events” topic. The `events.schema.json` and `events_v2.avsc` files must be present. The version bump is only necessary for major breaking changes of the schema (like changing the encoding). Most changes should be done in backward compatible manner, and keep the same version number even if the schema changes.

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -52,6 +52,7 @@ schema = get_schema(topic)
 #   "version": 1,
 # 	"schema": {
 # 		"$schema": "http://json-schema.org/draft-07/schema#",
+#       "compatibility_mode": "backward",
 # 		"type": "object",
 # 		...
 # 	}
@@ -86,7 +87,6 @@ Each schema version defines it's compatibility mode. There will be 2 to start bu
 - `backward` - Allows adding optional fields, removing optional fields, and changing from optional to required and required to optional. Required field cannot be added at once, it must be split into 2 separate releases.
 
 If `backward` is selected, CI in the schemas repository will ensure changes that are not allowed are not being introduced with a same version number
-
 
 ### **Option B (alternative, non-preferred option): Deploy a separate service**
 

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -11,7 +11,7 @@ Topic registration and schema validation of messages will be optional for the fo
 
 # Motivation
 
-Kafka is increasingly used as the message bus between services at Sentry. A Kafka topic and its’ schema is usually not internal to any one service, but is part of the contract between services.
+Kafka is increasingly used as the message bus between services at Sentry. Kafka topics and their schemas are usually not internal to any one service, but part of the contract between services.
 
 As Sentry grows, the number of message types and topics in use is exploding. We are marching further towards increasingly distributed ownership of data by product and infrastructure engineering teams. We have already seen an increase in the number of incidents related with invalid data and schema issues at Sentry. It is reasonable to expect this trend to continue as the number of topics, data types, teams and engineers contributing to Sentry grows.
 

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -90,6 +90,10 @@ Each schema version defines it's compatibility mode. There will be 2 to start bu
 
 If `backward` is selected, CI in the schemas repository will ensure changes that are not allowed are not being introduced with a same version number
 
+**Sentry release process:**
+
+We will use Craft / `publish` GitHub workflow for publishing releases like all Sentry libraries. Since this library is internal, the release will be auto approved and not subject to manual approval processes that apply to SDKs and customer installed packages.
+
 ### **Option B (alternative, non-preferred option): Deploy a separate service**
 
 No library is provided. Clients fetch data from the schemas service and need to know how to parse the schema from the response by themselves. The schemas service could either be built from scratch or we could deploy an existing open source implementation such as Confluent schema registry.

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -49,7 +49,7 @@ topic = "events"
 schema = get_schema(topic)
 # => {
 # 	"type": "json"
-#   "version": 1,
+# 	"version": 1,
 # 	"schema": {
 # 		"$schema": "http://json-schema.org/draft-07/schema#",
 # 		"compatibility_mode": "backward",

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -11,9 +11,9 @@ Topic registration and schema validation of messages will be optional for the fo
 
 # Motivation
 
-Kafka is increasingly used as the message bus between services at Sentry. A Kafka topic and its’ schema not owned by any one service, but is part of the contract between services.
+Kafka is increasingly used as the message bus between services at Sentry. A Kafka topic and its’ schema is usually not internal to any one service, but is part of the contract between services.
 
-As Sentry grows, the number of event types and topics in use is exploding. We are marching further towards increasingly distributed ownership of data by product and infrastructure engineering teams. We have already seen an increase in the number of incidents related with invalid data and schema issues at Sentry. It is reasonable to expect this trend to continue as the number of topics, data types, teams and engineers contributing to Sentry grows.
+As Sentry grows, the number of message types and topics in use is exploding. We are marching further towards increasingly distributed ownership of data by product and infrastructure engineering teams. We have already seen an increase in the number of incidents related with invalid data and schema issues at Sentry. It is reasonable to expect this trend to continue as the number of topics, data types, teams and engineers contributing to Sentry grows.
 
 The goals of the centralized schema repository are to:
 

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -65,8 +65,8 @@ Topic data will be stored as yaml. For example:
 ```
 topic: events
 schemas:
-- version: 1
-type: json
+    - version: 1
+    type: json
     resource: events.schema.json
     - version: 2
     type: avro

--- a/text/0072-kafka-schema-registry.md
+++ b/text/0072-kafka-schema-registry.md
@@ -86,7 +86,7 @@ In this example scenario, we decided to make a change to schemas on the “event
 Each schema version defines it's compatibility mode. There will be 2 to start but more can be added if we want to change or tighten the rules.
 
 - `none` - Any changes are allowed. Generally used if a feature is in dev to allow for fast iteration and breaking changes.
-- `backward` - Allows adding optional fields, removing optional fields, and changing from optional to required and required to optional. Required field cannot be added at once, it must be split into 2 separate releases.
+- `backward` - Allows adding optional fields and removing optional fields.
 
 If `backward` is selected, CI in the schemas repository will ensure changes that are not allowed are not being introduced with a same version number
 


### PR DESCRIPTION
This RFC proposes introducing a centralized schema repository for the Kafka topics in use at Sentry. It provides mappings between the Kafka topics we are using to the encoding format and schemas for messages on that topic.

[Rendered RFC](https://github.com/getsentry/rfcs/blob/schema-registry/text/0072-kafka-schema-registry.md)
