### PR TITLE
fix(exception groups): Fix typos

### DIFF
--- a/text/0079-exception-groups.md
+++ b/text/0079-exception-groups.md
@@ -570,9 +570,9 @@ Pros:
 
 Cons:
 
-- Potential to loose a lot of useful data.
+- Potential to lose a lot of useful data.
 - Misrepresents the exception that was actually raised.
-- Looses track of the actual location in source code where the exception group was raised.
+- Loses track of the actual location in source code where the exception group was raised.
 
 ## Splitting Events in the SDK
 


### PR DESCRIPTION
Just a quick proofreading fix I noticed.

P.S. It was an interesting read, and explained quite well. Nice job!
