### PR TITLE
rfc(decision): Replay Issue Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ This repository contains RFCs and DACIs. Lost?
 - [0081-sourcemap-debugid](text/0081-sourcemap-debugid.md): Reliable JavaScript/SourceMap processing via `DebugId`
 - [0084-move-docs-to-sentry-repository](text/0084-move-docs-to-sentry-repository.md): Move onboarding docs from sentry-docs over to sentry repository
 - [0086-sentry-bundler-plugins-api](text/0086-sentry-bundler-plugins-api.md): Sentry Bundler Plugins API
+- [0092-replay-issue-creation](text/0092-replay-issue-creation.md): Replay Issue Creation

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -15,7 +15,7 @@ We want to detect certain categories of ssues that can greatly benefit from vide
 
 # Options Considered
 
-### Option 1: SDK
+### Option 1: SDK Generates Issues Through a Generic Interface
 
 When the SDK encounters a "replay issue" it will make an HTTP request to a generic interface which will handle the issue creation process.
 
@@ -32,7 +32,7 @@ When the SDK encounters a "replay issue" it will make an HTTP request to a gener
    - E.g. "Experienced 10 occurences in the past hour".
 3. The replay containing the issue could not be sampled.
 
-### Option 2: Ingest
+### Option 2: SDK Generates Issues Through a Session-Replay Specific Interface
 
 The SDK publishes a "replay issue" to the Replay back-end. The back-end will decide to process the issue or not.
 

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -28,7 +28,7 @@ When the SDK encounters a "replay issue" it will make an HTTP request to a gener
 1. Uses quota.
 2. Unclear if we're able to use dynamic thresholds.
    - E.g. "Experienced 10 occurences in the past hour".
-3. The replay containing the issue could be sampled.
+3. The replay containing the issue could not be sampled.
 
 ### Option 2: Ingest
 

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -5,7 +5,9 @@
 
 # Summary
 
-We want to detect certain categories of issues only available through the Session Replay product. The first of these issues is the "Slow Click" detection issue.
+We want to detect certain categories of issues only available through the Session Replay product. These issues can only be detected on the SDK. The Replay back-end will never have enough data to find these issues. For that reason this is primarily an SDK driven workload with the Replay back-end acting as a middleman between the SDK and the Issues platform.
+
+Should the Replay SDK use the Replay back-end to generate new issues or should the SDK generate those issues through a generic, non-replay-specific interface?
 
 # Motivation
 

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -21,7 +21,9 @@ When the SDK encounters a "replay issue" it will make an HTTP request to a gener
 
 **Pros:**
 
-1. Can be tested in isolation without impacting existing production services.
+1. We can be tested in isolation without impacting existing production services.
+2. We can expose these new features in a more product agnostic way.
+   - This would allow us to reach much larger customer segments when compared to Replay customers.
 
 **Cons:**
 

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -5,7 +5,9 @@
 
 # Summary
 
-We want to detect certain categories of ssues that can greatly benefit from videos and context in the Session Replay product. These issues can only be detected on the SDK. The Replay back-end will never have enough data to find these issues. For that reason this is primarily an SDK driven workload. The question is: what role should the Replay back-end have in Replay issue creation? Should the Replay SDK use the Replay back-end to generate new issues or should the SDK generate those issues through a generic, non-replay-specific interface? Each option would have significantly different product implications that will be discussed below.
+The Session Replay team wants to detect certain categories of issues that can greatly benefit from videos and context in the Session Replay product.
+
+These issues can only be detected on the SDK. The Replay back-end will never have enough data to find these issues. For that reason this is primarily an SDK driven workload. What role should the Replay back-end have in Replay issue creation? Should the Replay SDK use the Replay back-end to generate new issues or should the SDK generate those issues through a generic, non-replay-specific interface? Each option would have significantly different product implications that will be discussed below.
 
 # Motivation
 
@@ -54,4 +56,4 @@ The SDK publishes a "replay issue" to the Replay back-end. The back-end will dec
 
 # Decisions
 
-No decisions have been made.
+We have decided to couple these new issues to the Session Replay product and use the Session Replay back-end to process issue events. Generic issue interfaces are not well supported at the time of writing. Using the Session Replay back-end we can accomplish our product goals. Should an HTTP interface for creating issue events be created this RFC can be re-addressed.

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -5,7 +5,7 @@
 
 # Summary
 
-We want to detect certain categories of issues only available through the Session Replay product. These issues can only be detected on the SDK. The Replay back-end will never have enough data to find these issues. For that reason this is primarily an SDK driven workload. The question is: what role should the Replay back-end have in Replay issue creation? Should the Replay SDK use the Replay back-end to generate new issues or should the SDK generate those issues through a generic, non-replay-specific interface? Each option would have significantly different product implications that will be discussed below.
+We want to detect certain categories of ssues that can greatly benefit from videos and context in the Session Replay product. These issues can only be detected on the SDK. The Replay back-end will never have enough data to find these issues. For that reason this is primarily an SDK driven workload. The question is: what role should the Replay back-end have in Replay issue creation? Should the Replay SDK use the Replay back-end to generate new issues or should the SDK generate those issues through a generic, non-replay-specific interface? Each option would have significantly different product implications that will be discussed below.
 
 # Motivation
 
@@ -25,7 +25,7 @@ When the SDK encounters a "replay issue" it will make an HTTP request to a gener
 
 **Cons:**
 
-1. Uses quota.
+1. Uses errors quota.
 2. Unclear if we're able to use dynamic thresholds.
    - E.g. "Experienced 10 occurences in the past hour".
 3. The replay containing the issue could not be sampled.
@@ -36,7 +36,7 @@ The SDK publishes a "replay issue" to the Replay back-end. The back-end will dec
 
 **Pros:**
 
-1. Does not use quota.
+1. Does not use errors quota.
 2. Overhead is low.
    - Publishing to a Kafka consumer can happen asynchronously.
 3. We can use dynamic thresholds.

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -17,7 +17,7 @@ We want to detect certain categories of issues only available through the Sessio
 
 ### Option 1: SDK
 
-We create a set of detectors on the SDK. When a detector is activated we submit a new issue event. The issue creation process would be generic and would not involve any Replay-specific services to process.
+When the SDK encounters a "replay issue" it will make an HTTP request to a generic interface which will handle the issue creation process.
 
 **Pros:**
 
@@ -26,16 +26,13 @@ We create a set of detectors on the SDK. When a detector is activated we submit 
 **Cons:**
 
 1. Uses quota.
-2. There's overhead associated with submitting a new issue through an HTTP request.
-3. Unable to use dynamic thresholds.
+2. Unclear if we're able to use dynamic thresholds.
    - E.g. "Experienced 10 occurences in the past hour".
-4. The replay containing the slow click could be sampled.
+3. The replay containing the issue could be sampled.
 
 ### Option 2: Ingest
 
-We create a set of detectors on the backend. When a detector is activated we publish to the issue creation topic.
-
-The SDK will update the recording breadcrumbs to include a "Slow Click" breadcrumb event type. The ingest server will use that event type to make an issue creation decision.
+The SDK publishes a "replay issue" to the Replay back-end. The back-end will decide to process the issue or not.
 
 **Pros:**
 

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -35,6 +35,8 @@ We create a set of detectors on the SDK. When a detector is activated we submit 
 
 We create a set of detectors on the backend. When a detector is activated we publish to the issue creation topic.
 
+The SDK will update the recording breadcrumbs to include a "Slow Click" breadcrumb event type. The ingest server will use that event type to make an issue creation decision.
+
 **Pros:**
 
 1. Does not use quota.
@@ -47,6 +49,7 @@ We create a set of detectors on the backend. When a detector is activated we pub
 **Cons:**
 
 1. Poor rollout could impact service availability during testing period.
+2. Requires coordination between the SDK and Ingest to create new issue types.
 
 # Unresolved questions
 

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -9,7 +9,7 @@ We want to detect certain categories of issues only available through the Sessio
 
 # Motivation
 
-1. Inform the long-term strategy for ingesting Session Replay generated issues.
+1. Inform the long-term strategy for detecting and ingesting Session Replay generated issues.
 2. Provide actionable feedback to developers that could not otherwise be captured in a performance span or error event.
 3. Increase product awareness in free-tier customers and encourage adoption.
 

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -11,7 +11,7 @@ We want to detect certain categories of issues only available through the Sessio
 
 1. Inform the long-term strategy for detecting and ingesting Session Replay generated issues.
 2. Provide actionable feedback to developers that could not otherwise be captured in a performance span or error event.
-3. Increase product awareness in free-tier customers and encourage adoption.
+3. Increase product awareness in platform customers and encourage adoption.
 
 # Options Considered
 

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -5,7 +5,7 @@
 
 # Summary
 
-We want to detect certain categories of issues only available through the Session Replay product. These issues can only be detected on the SDK. The Replay back-end will never have enough data to find these issues. For that reason this is primarily an SDK driven workload. The question is: what role should the Replay back-end have in Replay issue creation? Should the Replay SDK use the Replay back-end to generate new issues or should the SDK generate those issues through a generic, non-replay-specific interface?
+We want to detect certain categories of issues only available through the Session Replay product. These issues can only be detected on the SDK. The Replay back-end will never have enough data to find these issues. For that reason this is primarily an SDK driven workload. The question is: what role should the Replay back-end have in Replay issue creation? Should the Replay SDK use the Replay back-end to generate new issues or should the SDK generate those issues through a generic, non-replay-specific interface? Each option would have significantly different product implications that will be discussed below.
 
 # Motivation
 

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -1,0 +1,35 @@
+- Start Date: 2023-05-15
+- RFC Type: decision
+- RFC PR: https://github.com/getsentry/rfcs/pull/92
+- RFC Status: draft
+
+# Summary
+
+One paragraph explanation of the feature or document purpose.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Background
+
+The reason this decision or document is required. This section might not always exist.
+
+# Supporting Data
+
+[Metrics to help support your decision (if applicable).]
+
+# Options Considered
+
+If an RFC does not know yet what the options are, it can propose multiple options. The
+preferred model is to propose one option and to provide alternatives.
+
+# Drawbacks
+
+Why should we not do this? What are the drawbacks of this RFC or a particular option if
+multiple options are presented.
+
+# Unresolved questions
+
+- What parts of the design do you expect to resolve through this RFC?
+- What issues are out of scope for this RFC but are known?

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -5,31 +5,51 @@
 
 # Summary
 
-One paragraph explanation of the feature or document purpose.
+We want to detect certain categories of issues only available through the Session Replay product. The first of these issues is the "Slow Click" detection issue.
 
 # Motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
-
-# Background
-
-The reason this decision or document is required. This section might not always exist.
-
-# Supporting Data
-
-[Metrics to help support your decision (if applicable).]
+1. Inform the long-term strategy for ingesting Session Replay generated issues.
+2. Provide actionable feedback to developers that could not otherwise be captured in a performance span or error event.
+3. Increase product awareness in free-tier customers and encourage adoption.
 
 # Options Considered
 
-If an RFC does not know yet what the options are, it can propose multiple options. The
-preferred model is to propose one option and to provide alternatives.
+### Option 1: SDK
 
-# Drawbacks
+We create a set of detectors on the SDK. When a detector is activated we submit a new issue event. The issue creation process would be generic and would not involve any Replay-specific services to process.
 
-Why should we not do this? What are the drawbacks of this RFC or a particular option if
-multiple options are presented.
+**Pros:**
+
+1. Can be tested in isolation without impacting existing production services.
+
+**Cons:**
+
+1. Uses quota.
+2. There's overhead associated with submitting a new issue through an HTTP request.
+3. Unable to use dynamic thresholds.
+   - E.g. "Experienced 10 occurences in the past hour".
+4. The replay containing the slow click could be sampled.
+
+### Option 2: Ingest
+
+We create a set of detectors on the backend. When a detector is activated we publish to the issue creation topic.
+
+**Pros:**
+
+1. Does not use quota.
+2. Overhead is low.
+   - Publishing to a Kafka consumer can happen asynchronously.
+3. We can use dynamic thresholds.
+   - E.g. "Experienced 10 occurences in the past hour".
+4. Replay is guaranteed to be sampled.
+
+**Cons:**
+
+1. Poor rollout could impact service availability during testing period.
 
 # Unresolved questions
 
-- What parts of the design do you expect to resolve through this RFC?
-- What issues are out of scope for this RFC but are known?
+# Decisions
+
+No decisions have been made.

--- a/text/0092-replay-issue-creation.md
+++ b/text/0092-replay-issue-creation.md
@@ -5,9 +5,7 @@
 
 # Summary
 
-We want to detect certain categories of issues only available through the Session Replay product. These issues can only be detected on the SDK. The Replay back-end will never have enough data to find these issues. For that reason this is primarily an SDK driven workload with the Replay back-end acting as a middleman between the SDK and the Issues platform.
-
-Should the Replay SDK use the Replay back-end to generate new issues or should the SDK generate those issues through a generic, non-replay-specific interface?
+We want to detect certain categories of issues only available through the Session Replay product. These issues can only be detected on the SDK. The Replay back-end will never have enough data to find these issues. For that reason this is primarily an SDK driven workload. The question is: what role should the Replay back-end have in Replay issue creation? Should the Replay SDK use the Replay back-end to generate new issues or should the SDK generate those issues through a generic, non-replay-specific interface?
 
 # Motivation
 


### PR DESCRIPTION
This RFC proposes two possible paths for creating Replay issues.

[Rendered RFC](https://github.com/getsentry/rfcs/blob/rfc/replay-issue-creation/text/0092-replay-issue-creation.md)