### PR TITLE
feat: Update RFC#91 with new token format

### DIFF
--- a/text/0091-ci-upload-tokens.md
+++ b/text/0091-ci-upload-tokens.md
@@ -62,7 +62,7 @@ sntrys_eyJpYXQiOjE2ODczMzY1NDMuNjk4NTksInVybCI6bnVsbCwicmVnaW9uX3VybCI6Imh0dHA6L
 ```
 
 * `PREFIX`: `sntrys_` - this is static and helps to identify this is a Sentry token.
-* `FACTS`: A padding-less base64 encoded JSON string of the facts.
+* `FACTS`: A base64 encoded JSON string of the facts.
 * `SECRET`: A random secret part for the token. We may use `b64encode(secrets.token_bytes(32)).decode("ascii").rstrip("=")`, but this is an implementation detail. 
 
 A serialized token is added a custom prefix `sntrys_` (sentry structure) to make
@@ -130,10 +130,7 @@ def parse_token(token: str):
     if not token.startswith("sntrys_") or token.count('_') != 2:
         return None
 
-    # Note: We add == to the end of the string, because we remove the base64 padding when generating the token
-    # But python expects the correct amount of padding to be present, erroring out otherwise
-    # However, any _excess_ padding is ignored, so we just add the max. amount of padding and it works
-    payload_hashed = token[7:token.rindex('_')] + '=='
+    payload_hashed = token[7:token.rindex('_')]
     payload_str = b64decode((payload_hashed).encode('ascii')).decode("ascii")
     return json.loads(payload_str)
 ```

--- a/text/0091-ci-upload-tokens.md
+++ b/text/0091-ci-upload-tokens.md
@@ -63,7 +63,7 @@ sntrys_eyJpYXQiOjE2ODczMzY1NDMuNjk4NTksInVybCI6bnVsbCwicmVnaW9uX3VybCI6Imh0dHA6L
 
 * `PREFIX`: `sntrys_` - this is static and helps to identify this is a Sentry token.
 * `FACTS`: A padding-less base64 encoded JSON string of the facts.
-* `SECRET`: A random secret part for the token. We may use `base64_encode_str(secrets.token_hex(32))`, but this is an implementation detail. 
+* `SECRET`: A random secret part for the token. We may use `b64encode(uuid4().bytes).decode("ascii").rstrip("=")`, but this is an implementation detail. 
 
 A serialized token is added a custom prefix `sntrys_` (sentry structure) to make
 it possible to detect it by security scrapers.  Anyone handling such a token is

--- a/text/0091-ci-upload-tokens.md
+++ b/text/0091-ci-upload-tokens.md
@@ -63,7 +63,7 @@ sntrys_eyJpYXQiOjE2ODczMzY1NDMuNjk4NTksInVybCI6bnVsbCwicmVnaW9uX3VybCI6Imh0dHA6L
 
 * `PREFIX`: `sntrys_` - this is static and helps to identify this is a Sentry token.
 * `FACTS`: A padding-less base64 encoded JSON string of the facts.
-* `SECRET`: A random secret part for the token. We may use `b64encode(uuid4().bytes).decode("ascii").rstrip("=")`, but this is an implementation detail. 
+* `SECRET`: A random secret part for the token. We may use `b64encode(secrets.token_bytes(32)).decode("ascii").rstrip("=")`, but this is an implementation detail. 
 
 A serialized token is added a custom prefix `sntrys_` (sentry structure) to make
 it possible to detect it by security scrapers.  Anyone handling such a token is

--- a/text/0091-ci-upload-tokens.md
+++ b/text/0091-ci-upload-tokens.md
@@ -63,13 +63,15 @@ sntrys_eyJpYXQiOjE2ODczMzY1NDMuNjk4NTksInVybCI6bnVsbCwicmVnaW9uX3VybCI6Imh0dHA6L
 
 * `PREFIX`: `sntrys_` - this is static and helps to identify this is a Sentry token.
 * `FACTS`: A padding-less base64 encoded JSON string of the facts.
-* `SECRET`: A random secret. We may use `base64_encode_str(uuid4().hex)`, but this is an implementation detail.
+* `SECRET`: A random secret part for the token. We may use `base64_encode_str(secrets.token_hex(32))`, but this is an implementation detail. 
 
 A serialized token is added a custom prefix `sntrys_` (sentry structure) to make
 it possible to detect it by security scrapers.  Anyone handling such a token is
 required to check for the `sntrys_` prefix and disregard it before parsing it.  This
 can also be used by the client side to detect a structural token if the client is
 interested in extracting data from the token.
+
+The purpose of the secret is that the resulting token is not guessable. It should be a randomly generated string that is different for each token.
 
 ## Token Facts
 


### PR DESCRIPTION
This PR updates RFC #91 with an adjusted token format. We did some experimentation and started implementation and noticed shortcomings of the JWT format, so we decided to change course here to a more simple base64 format.

[Rendered RFC](https://github.com/getsentry/rfcs/blob/fn/update-org-token-format/text/0091-ci-upload-tokens.md)
