### PR TITLE
feat: Add `implementation` state (amend)

### DIFF
--- a/text/0001-workflow.md
+++ b/text/0001-workflow.md
@@ -25,6 +25,7 @@ The are three kinds of RFCs:
 - `draft`: this RFC is currently in draft state.
 - `active`: this RFC is currently active, which means that the contents of the document reference the current state of affairs and are supposed to be followed.
   This status is used for RFCs that are informational or general guides.
+- `implementation`: The RFC was discussed and is currently in a trail period of being implemented. Potential learnings will go into the RFC before it's finally approved. This step is optional and can be considered by the author as a forcing function to move forward.
 - `approved`: the approver of an RFC approved the decision.
 - `withdrawn`: the RFC was withdrawn. Typically such RFCs are not visible in the repository as the corresponding PRs are not merged unless they are withdrawn after being accepted.
 - `replaced`: the RFC was later replaced by another RFC.


### PR DESCRIPTION
Many RFCs are in a state where meaningful feedback only occurs once we start to implement them. So after we wrote it, asked for feedback etc.

We miss a forcing function for people to think about the problem to have a strong opinion about a topic.

This doesn't apply to every RFC, but it's a recurring theme, especially in SDKs and topics around APIs.
And I don't want to blame anyone here, I think this is mostly how people work - but I feel it's annoying and adds unnecessary friction.
The person driving RFCs also feels it when this happens that they haven't gotten any meaningful feedback yet.

That's why I am proposing to add a new RFC state called `implementation`

### FAQ:

_Why can't it stay in `draft`?_
The RFC is still not approved so it's a draft, though the `implementation` state really is a forcing function for the author to move forward and also demonstrates more maturity than just `draft`

_Should we just have a sync meeting with the people involved to come to a conclusion?_
Nothing beats actually writing the code and seeing where it falls short, sync meetings where everyone says LGTM won't solve it.

_Can we create a Github Project or Workflow to cover this case instead?_
That's too much complexity for everyone to keep track of and maintain.

_Why are POCs not solving this?_
POCs for changes are definitely welcome and help a lot but often are not enough to get feedback from different teams or people. Only when it gets serious and people make it their problem to solve they have opinions about it.

_Will this new state fix my entire life?_
No