### PR TITLE
docs: Clarify span op/description for metric correlation in span creating mode

### DIFF
--- a/text/0123-metrics-correlation.md
+++ b/text/0123-metrics-correlation.md
@@ -25,7 +25,7 @@ These summaries are automatically added when using the basic `metrics` API.
 Whenever a metrics API is used it operates in either span seeking or in span creating mode.  Most
 of the metrics APIs are span seeking which means that they record a measurement in relation
 to that span.  Some APIs (such as `metrics.timing` when used with a code block) will instead
-create a span and bind it.
+create a span with `op="metric.timing", description=metric.key` and bind it.
 
 ```python
 def process_batch(batch):
@@ -48,7 +48,7 @@ where 3 succeed and two fail, the following summaries might be associated:
 ```json
 {
     "span_id": "deadbeef",
-    "op": "metric.timer",
+    "op": "metric.timing",
     "_metrics_summary": {
         "d:processor.process_batch@millisecond": [
             {


### PR DESCRIPTION
Clarify span op and description, fix example.

Based on 
 * python impl: https://github.com/getsentry/sentry-python/blob/0901953c93071e858f4da67c1e864766ae19c002/sentry_sdk/metrics.py#L800C48-L800C61
 * ruby impl: https://github.com/getsentry/sentry-ruby/pull/2255/files#diff-44d204371288f9a84dd2ed1c054a2b09d85388267ba249b83ca08ea251b1e6f9R40

[Rendered RFC](https://github.com/getsentry/rfcs/blob/markushi/metric-span-correlation-docs/text/0123-metrics-correlation.md)
