### PR TITLE
fix: Add 0119-rust-in-sentry to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This repository contains RFCs and DACIs. Lost?
 - [0106-artifact-indices](text/0106-artifact-indices.md): Improvements to Source Maps Processing
 - [0116-sentry-semantic-conventions](text/0116-sentry-semantic-conventions.md): Sentry Semantic Conventions
 - [0118-mobile-transactions-and-spans](text/0118-mobile-transactions-and-spans.md): Transactions and Spans for Mobile Platforms
+- [0119-rust-in-sentry](text/0119-rust-in-sentry.md): Make it easier to use Rust code from Sentry/Python.
 - [0123-metrics-correlation](text/0123-metrics-correlation.md): This RFC addresses the high level metrics to span correlation system
 - [0126-sdk-spans-aggregator](text/0126-sdk-spans-aggregator.md): SDK Spans Aggregator
 - [0129-video-replay-envelope](text/0129-video-replay-envelope.md): Video-based replay envelope format


### PR DESCRIPTION
Suggested by failing CI job on main branch https://github.com/getsentry/rfcs/actions/runs/8631457289/job/23659905250.
