### PR TITLE
ci: Run checking all RFCs linked for PRs

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
To avoid fixes like https://github.com/getsentry/rfcs/pull/134.
