### PR TITLE
fix: View Hierarchy positioning is relative

### DIFF
--- a/text/0033-view-hierarchy.md
+++ b/text/0033-view-hierarchy.md
@@ -50,6 +50,7 @@ Some remarks on the example:
  * `windows`: contains all visible windows, on mobile it's typically just one or two (e.g. if a dialog is open)
  * `type`: The fully qualified widget class name, this name may be obfuscated on certain platforms (e.g. Android release builds with proguard enabled)
  * `children` nests all child UI widgets, which then builds up the whole UI tree
+ * Positioning attributes (`x`, `y`, `z`) are relative to the parent window. To enable absolute positioning, the `rendering_system` should contain `absolute`
 
 A typical Android/iOS view hierarchy for a single window consists of around 100-200 objects. Taking the attributes from the example above this generates a raw JSON file with a size of around 50KB. More complex view hierarchies, for example a Unity game, may hold 1000-2000 objects, producing a JSON file of around 500KB.
 


### PR DESCRIPTION
It was not mentioned in the RFC but View Hierarchy positioning is expected to be relative to the parent window. 

In Sentry, flutter projects were hard-coded to use absolute positioning but it was not possible to otherwise override this. 

I opened a PR to allow overriding this by including `absolute` in the `rendering_system`:
- https://github.com/getsentry/sentry/pull/83292
