### PR TITLE
ref: Replace deprecated `gen_ai.response.time_to_first_token`

### DIFF
--- a/text/0153-decoupling-sentrys-generative-ai-conventions-from-open-telemetry.md
+++ b/text/0153-decoupling-sentrys-generative-ai-conventions-from-open-telemetry.md
@@ -120,7 +120,7 @@ AI Client Spans represent one request to a provider handled by a single model wi
 | `gen_ai.response.model` | Required if in the model response |
 | `gen_ai.response.finish_reasons` | Required if in the model response |
 | `gen_ai.response.streaming` | Required |
-| `gen_ai.response.time_to_first_token` | Required if streaming response |
+| `gen_ai.response.time_to_first_chunk` | Required if streaming response |
 
 #### Token Usage Attribute
 
@@ -318,7 +318,7 @@ Sensitive attributes can be controlled by either the `record_inputs` or the `rec
 | `gen_ai.response.finish_reasons` | string[] | - |
 | `gen_ai.response.id` | string | - |
 | `gen_ai.response.streaming` | boolean | - |
-| `gen_ai.response.time_to_first_token` | double | - |
+| `gen_ai.response.time_to_first_chunk` | double | - |
 
 #### Token Usage Attributes
 


### PR DESCRIPTION
The `gen_ai.response.time_to_first_token` attribute was replaced by `gen_ai.response.time_to_first_chunk` with https://github.com/getsentry/sentry-conventions/commit/ff120dff15aa5c2e13cee871bf2bfc44d4bc7916.

Update references to their replacement.
